### PR TITLE
Fix logo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ AllenAct is MIT licensed, as found in the [LICENSE](LICENSE.md) file.
 AllenAct is an open-source project built by members of the PRIOR research group at the Allen Institute for Artificial Intelligence (AI2). 
 
 <div align="left">
-    <a href="//www.prior.allenai.org/" target="_blank">
+    <a href="//prior.allenai.org/" target="_blank">
         <img src="docs/img/ai2-prior.svg" width="400">
     </a>
     <br>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="center">
-    <a href="https://allenact.org/" target="_blank">
-        <img src="docs/img/AllenAct.svg" width="350" />
-    </a>
+    <img src="docs/img/AllenAct.svg" width="350" />
     <br>
     <i><h3>An open source framework for research in Embodied-AI</h3></i>
     </p>
@@ -49,7 +47,7 @@ AllenAct is MIT licensed, as found in the [LICENSE](LICENSE.md) file.
 AllenAct is an open-source project built by members of the PRIOR research group at the Allen Institute for Artificial Intelligence (AI2). 
 
 <div align="left">
-    <a href="https://prior.allenai.org/" target="_blank">
+    <a href="https://www.prior.allenai.org/" target="_blank">
         <img src="docs/img/ai2-prior.svg" width="400">
     </a>
     <br>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ AllenAct is MIT licensed, as found in the [LICENSE](LICENSE.md) file.
 AllenAct is an open-source project built by members of the PRIOR research group at the Allen Institute for Artificial Intelligence (AI2). 
 
 <div align="left">
-    <a href="https://www.prior.allenai.org/" target="_blank">
+    <a href="//www.prior.allenai.org/" target="_blank">
         <img src="docs/img/ai2-prior.svg" width="400">
     </a>
     <br>


### PR DESCRIPTION
- Remove link from AllenAct logo to its website (since it's homepage matches the readme)
- Drop the https from the PRIOR link for possible edge cases.