### PR TITLE
Improving documentation generation and style.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ pre-commit = "*"
 gitpython = "*"
 ipython = "*"
 mkdocs = "==1.1.2"
-mathy-pydoc = "==0.7.18"
+pydoc-markdown = "==3.4.0"
 pytest = "*"
 coverage = "*"
 

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,9 @@
+/* Allow word-breaks in headers */
+h1 {
+  word-wrap: break-word;
+}
+
+/* Don't have the edit button as it's broken for us */
+.md-content__button {
+    display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,11 +16,13 @@ theme:
   - typescript
   - json
 
+extra_css:
+- css/extra.css
+
 google_analytics: [UA-120916510-8, allenact.org]
 
 repo_name: allenai/allenact
 repo_url: https://github.com/allenai/allenact
-edit_uri: edit/master/docs/
 docs_dir: docs
 
 nav:
@@ -88,7 +90,15 @@ nav:
   - plugins:
     - habitat_plugin:
       - habitat_constants: api/plugins/habitat_plugin/habitat_constants.md
+      - habitat_tasks: api/plugins/habitat_plugin/habitat_tasks.md
+      - habitat_sensors: api/plugins/habitat_plugin/habitat_sensors.md
+      - habitat_environment: api/plugins/habitat_plugin/habitat_environment.md
       - habitat_preprocessors: api/plugins/habitat_plugin/habitat_preprocessors.md
+      - habitat_task_samplers: api/plugins/habitat_plugin/habitat_task_samplers.md
+      - scripts:
+        - agent_demo: api/plugins/habitat_plugin/scripts/agent_demo.md
+        - make_map: api/plugins/habitat_plugin/scripts/make_map.md
+      - habitat_utils: api/plugins/habitat_plugin/habitat_utils.md
     - lighthouse_plugin:
       - lighthouse_models: api/plugins/lighthouse_plugin/lighthouse_models.md
       - lighthouse_environment: api/plugins/lighthouse_plugin/lighthouse_environment.md
@@ -179,6 +189,11 @@ nav:
           - pointnav_robothor_depth_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/robothor/pointnav_robothor_depth_simpleconvgru_ddppo.md
           - pointnav_robothor_rgb_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/robothor/pointnav_robothor_rgb_simpleconvgru_ddppo.md
           - pointnav_robothor_base: api/projects/pointnav_baselines/experiments/robothor/pointnav_robothor_base.md
+        - habitat:
+          - pointnav_habitat_rgb_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/habitat/pointnav_habitat_rgb_simpleconvgru_ddppo.md
+          - pointnav_habitat_rgbd_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/habitat/pointnav_habitat_rgbd_simpleconvgru_ddppo.md
+          - pointnav_habitat_base: api/projects/pointnav_baselines/experiments/habitat/pointnav_habitat_base.md
+          - pointnav_habitat_depth_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/habitat/pointnav_habitat_depth_simpleconvgru_ddppo.md
         - pointnav_base: api/projects/pointnav_baselines/experiments/pointnav_base.md
         - ithor:
           - pointnav_ithor_rgbd_simpleconvgru_ddppo: api/projects/pointnav_baselines/experiments/ithor/pointnav_ithor_rgbd_simpleconvgru_ddppo.md
@@ -188,9 +203,11 @@ nav:
       - models:
         - point_nav_models: api/projects/pointnav_baselines/models/point_nav_models.md
     - tutorials:
+      - pointnav_habitat_rgb_ddppo: api/projects/tutorials/pointnav_habitat_rgb_ddppo.md
       - pointnav_robothor_rgb_ddppo: api/projects/tutorials/pointnav_robothor_rgb_ddppo.md
       - object_nav_ithor_dagger_then_ppo_one_object: api/projects/tutorials/object_nav_ithor_dagger_then_ppo_one_object.md
       - pointnav_ithor_rgb_ddppo: api/projects/tutorials/pointnav_ithor_rgb_ddppo.md
+      - pointnav_robothor_rgb_ddppo_viz: api/projects/tutorials/pointnav_robothor_rgb_ddppo_viz.md
       - object_nav_ithor_ppo_one_object: api/projects/tutorials/object_nav_ithor_ppo_one_object.md
       - minigrid_tutorial: api/projects/tutorials/minigrid_tutorial.md
   - tests:
@@ -215,7 +232,6 @@ markdown_extensions:
 - meta
 - admonition
 - codehilite
-- extra
 
 # extra_javascript:
 #  - javascripts/extra.js

--- a/projects/tutorials/pointnav_robothor_rgb_ddppo_viz.py
+++ b/projects/tutorials/pointnav_robothor_rgb_ddppo_viz.py
@@ -18,6 +18,14 @@ from plugins.robothor_plugin.robothor_viz import ThorViz
 class ObjectNavRoboThorRGBPPOVizExperimentConfig(
     ObjectNavRoboThorRGBPPOExperimentConfig
 ):
+    """ExperimentConfig used to demonstrate how to set up visualization code.
+
+    # Attributes
+
+    viz_ep_ids : Scene names that will be visualized.
+    viz_video_ids : Scene names that will have videos visualizations associated with them.
+    """
+
     viz_ep_ids = [
         "FloorPlan_Train1_1_0",
         "FloorPlan_Train1_1_7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ aws-requests-auth==0.4.3
 backcall==0.2.0
 black==19.10b0
 blosc==1.9.1
-botocore==1.17.50
+botocore==1.17.54
 cached-property==1.5.1
 cachetools==4.1.1
 Cerberus==1.3.2
@@ -25,6 +25,8 @@ cycler==0.10.0
 decorator==4.4.2
 distlib==0.3.1
 docformatter==1.3.1
+docspec==0.2.0
+docspec-python==0.0.7
 docstr-coverage==1.2.0
 docutils==0.15.2
 filelock==3.0.12
@@ -42,7 +44,7 @@ grpcio==1.31.0
 gym==0.17.2
 gym-minigrid @ https://github.com/maximecb/gym-minigrid/archive/master.zip
 h5py==2.10.0
-identify==1.4.29
+identify==1.4.30
 idna==2.10
 imageio==2.9.0
 imageio-ffmpeg==0.4.2
@@ -59,16 +61,16 @@ joblib==0.16.0
 Keras-Preprocessing==1.1.2
 kiwisolver==1.2.0
 livereload==2.6.3
+llvmlite==0.34.0
 lunr==0.5.8
 Markdown==3.2.2
 MarkupSafe==1.1.1
-mathy-pydoc==0.7.18
 matplotlib==3.3.1
 mccabe==0.6.1
 mkdocs==1.1.2
 mkdocs-material==5.5.3
 mkdocs-material-extensions==1.0
-more-itertools==8.4.0
+more-itertools==8.5.0
 moviepy==1.0.3
 msgpack==1.0.0
 mypy==0.782
@@ -76,6 +78,17 @@ mypy-extensions==0.4.3
 networkx==2.5
 nltk==3.5
 nodeenv==1.5.0
+nr.collections==0.0.1
+nr.databind.core==0.0.21
+nr.databind.json==0.0.13
+nr.fs==1.6.2
+nr.interface==0.0.3
+nr.metaclass==0.0.5
+nr.parsing.date==0.3.0
+nr.pylang.utils==0.0.3
+nr.stream==0.0.4
+nr.sumtype==0.0.3
+nr.utils.re==0.1.0
 numpy==1.19.1
 numpy-quaternion==2020.5.19.15.27.24
 oauthlib==3.1.0
@@ -86,6 +99,7 @@ packaging==20.4
 pandas==1.1.1
 parso==0.7.1
 pathspec==0.8.0
+pathtools==0.1.2
 patsy==0.5.1
 pep517==0.8.2
 pexpect==4.8.0
@@ -98,14 +112,15 @@ plette==0.2.3
 pluggy==0.13.1
 pre-commit==2.7.1
 proglog==0.1.9
-progressbar2==3.51.4
-prompt-toolkit==3.0.6
+progressbar2==3.52.1
+prompt-toolkit==3.0.7
 protobuf==3.13.0
 ptyprocess==0.6.0
 py==1.9.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.6.0
+pydoc-markdown==3.4.0
 pyflakes==2.2.0
 pyglet==1.5.0
 Pygments==2.6.1
@@ -147,6 +162,7 @@ untokenize==0.1.1
 urllib3==1.25.10
 virtualenv==20.0.31
 vistir==0.5.2
+watchdog==0.10.3
 wcwidth==0.2.5
 Werkzeug==1.0.1
 wrapt==1.12.1


### PR DESCRIPTION
This PR moves us from using `mathy_pydoc` to using `pydoc-markdown` when generating the files under `docs/api`. `pydoc-markdown` allows for a much larger amount of customization in how these docs are generated and seems to be non-trivially faster.