### PR TITLE
bug fix preventing len(None) 

### DIFF
--- a/docs/howtos/defining-an-experiment.md
+++ b/docs/howtos/defining-an-experiment.md
@@ -285,7 +285,9 @@ class ObjectNavThorPPOExperimentConfig(ExperimentConfig):
         res["env_args"] = {}
         res["env_args"].update(self.ENV_ARGS)
         res["env_args"]["x_display"] = (
-            ("0.%d" % devices[process_ind % len(devices)]) if len(devices) > 0 else None
+            ("0.%d" % devices[process_ind % len(devices)])
+            if devices is not None and len(devices) > 0
+            else None
         )
         return res
     ...

--- a/projects/tutorials/object_nav_ithor_ppo_one_object.py
+++ b/projects/tutorials/object_nav_ithor_ppo_one_object.py
@@ -193,7 +193,9 @@ class ObjectNavThorPPOExperimentConfig(ExperimentConfig):
         res["env_args"] = {}
         res["env_args"].update(self.ENV_ARGS)
         res["env_args"]["x_display"] = (
-            ("0.%d" % devices[process_ind % len(devices)]) if len(devices) > 0 else None
+            ("0.%d" % devices[process_ind % len(devices)])
+            if devices is not None and len(devices) > 0
+            else None
         )
         return res
 
@@ -217,7 +219,9 @@ class ObjectNavThorPPOExperimentConfig(ExperimentConfig):
         res["env_args"] = {}
         res["env_args"].update(self.ENV_ARGS)
         res["env_args"]["x_display"] = (
-            ("0.%d" % devices[process_ind % len(devices)]) if len(devices) > 0 else None
+            ("0.%d" % devices[process_ind % len(devices)])
+            if devices is not None and len(devices) > 0
+            else None
         )
         return res
 
@@ -241,6 +245,8 @@ class ObjectNavThorPPOExperimentConfig(ExperimentConfig):
         res["env_args"] = {}
         res["env_args"].update(self.ENV_ARGS)
         res["env_args"]["x_display"] = (
-            ("0.%d" % devices[process_ind % len(devices)]) if len(devices) > 0 else None
+            ("0.%d" % devices[process_ind % len(devices)])
+            if devices is not None and len(devices) > 0
+            else None
         )
         return res


### PR DESCRIPTION
`devices` is an optional parameters defaulted to `None`. But, `len(devices)` is later called. I've just added a check for when `devices is None` which short-circuits the `len(devices) > 0` check.

(It looks like this check `if devices is not None and len(devices) > 0` was previously added to a few other files, just not the defining-an-experiment + its docs.)