### PR TITLE
adding python-blosc to dependencies to resolve missing skbuild error

### DIFF
--- a/conda/environment-base.yml
+++ b/conda/environment-base.yml
@@ -7,7 +7,6 @@ dependencies:
   - python-blosc
   - black=19.10b0
   - colour
-  - python-blosc
   - coverage
   - filelock
   - flake8

--- a/conda/environment-base.yml
+++ b/conda/environment-base.yml
@@ -4,8 +4,10 @@ channels:
   - pytorch
   - conda-forge
 dependencies:
+  - python-blosc
   - black=19.10b0
   - colour
+  - python-blosc
   - coverage
   - filelock
   - flake8


### PR DESCRIPTION
Repro steps for error:
```
wget https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
sh Anaconda3-2020.11-Linux-x86_64.sh
<LOGOUT/LOGIN>
git clone https://github.com/allenai/allenact
cd allenact
conda env create --file ./conda/environment-10.2.yml --name allenact
=====
Pip subprocess error:
    ERROR: Command errored out with exit status 1:
     command: /home/erick/miniconda3/envs/allenact/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-li6_7mfu/blosc_b4f3852bafea48a890397efc5c01d970/setup.py'"'"'; __file__='"'"'/tmp/pip-install-li6_7mfu/blosc_b4f3852bafea48a890397efc5c01d970/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-pobwl7km
         cwd: /tmp/pip-install-li6_7mfu/blosc_b4f3852bafea48a890397efc5c01d970/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-li6_7mfu/blosc_b4f3852bafea48a890397efc5c01d970/setup.py", line 18, in <module>
        from skbuild import setup
    ModuleNotFoundError: No module named 'skbuild'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```