### PR TITLE
Update extra_requirements.txt

### DIFF
--- a/allenact_plugins/robothor_plugin/extra_requirements.txt
+++ b/allenact_plugins/robothor_plugin/extra_requirements.txt
@@ -2,3 +2,4 @@ ai2thor>=2.5.3
 numpy-quaternion
 pyquaternion>=0.9.9
 colour
+numba


### PR DESCRIPTION
Without numba, the following message will get emitted from quaternion/numba_wrapper.py:

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Could not import from numba, which means that some
parts of this code may run MUCH more slowly.  You
may wish to install numba.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!