### PR TITLE
Inference tutorial fix

### DIFF
--- a/allenact/base_abstractions/experiment_config.py
+++ b/allenact/base_abstractions/experiment_config.py
@@ -126,6 +126,12 @@ class MachineParams(object):
 
         return self._sensor_preprocessor_graph_cached
 
+    def set_visualizer(self, viz: VizSuite):
+        if self._visualizer_cached is None:
+            self._visualizer_maybe_builder = viz
+        else:
+            get_logger().warning("Ignoring viz (already instantiated)")
+
     @property
     def visualizer(self) -> Optional[VizSuite]:
         if self._visualizer_maybe_builder is None:

--- a/allenact/utils/viz_utils.py
+++ b/allenact/utils/viz_utils.py
@@ -641,7 +641,7 @@ class ActorViz(AbstractViz):
 
     def make_fig(self, episode_src, episode_id):
         # Concatenate along step axis (0, reused from kept sampler axis)
-        mat = np.concatenate(episode_src, axis=0).squeeze(-2)  # also removes agent axis
+        mat = np.concatenate(episode_src, axis=0)
 
         fig, ax = plt.subplots(figsize=self.figsize)
         ax.matshow(mat)
@@ -873,13 +873,22 @@ class VizSuite(AbstractViz):
                     res = res[flattened_name]
                     res, episode_dim = res
 
+                if rollout.step > 0:
+                    if rollout.step > res.shape[0]:
+                        # e.g. rnn with only latest memory saved
+                        rollout_step = res.shape[0] - 1
+                    else:
+                        rollout_step = rollout.step - 1
+                else:
+                    if rollout.num_steps - 1 < res.shape[0]:
+                        rollout_step = rollout.num_steps - 1
+                    else:
+                        # e.g. rnn with only latest memory saved
+                        rollout_step = res.shape[0] - 1
+
                 # Select latest step
                 res = res.narrow(
-                    dim=0,  # step dimension
-                    start=rollout.step - 1
-                    if rollout.step > 0
-                    else rollout.num_steps - 1,
-                    length=1,
+                    dim=0, start=rollout_step, length=1,  # step dimension
                 )  # 1 x ... x sampler x ...
 
                 # get_logger().debug("basic collect h {}".format(res[..., 0]))

--- a/projects/tutorials/running_inference_tutorial.py
+++ b/projects/tutorials/running_inference_tutorial.py
@@ -170,9 +170,8 @@ class PointNavRoboThorRGBPPOVizExperimentConfig(PointNavRoboThorRGBPPOExperiment
 
     def machine_params(self, mode="train", **kwargs):
         res = super().machine_params(mode, **kwargs)
-        res["visualizer"] = None
         if mode == "test":
-            res["visualizer"] = self.get_viz(mode)
+            res.set_visualizer(self.get_viz(mode))
 
         return res
 


### PR DESCRIPTION
- Fixed experiment config
- Added setter for `VizSuite` in `MachineParams`
- Fixed access to rollouts (for RNN with only latest memory saved)
- Other minor fixes