### PR TITLE
Masks in rollouts storage should start with zeros, not ones.

### DIFF
--- a/allenact/algorithms/onpolicy_sync/storage.py
+++ b/allenact/algorithms/onpolicy_sync/storage.py
@@ -57,7 +57,7 @@ class RolloutStorage(object):
         self.rewards: Optional[torch.Tensor] = None
         self.action_log_probs: Optional[torch.Tensor] = None
 
-        self.masks = torch.ones(num_steps + 1, num_samplers, 1)
+        self.masks = torch.zeros(num_steps + 1, num_samplers, 1)
 
         self.action_space = actor_critic.action_space
 


### PR DESCRIPTION
The masks are defined to be 0 when done, otherwise 1. Namely, in the engine we have:
```python
        masks = torch.tensor(
            [0.0 if done else 1.0 for done in dones],
            dtype=torch.float32,
            device=self.device,  # type:ignore
        ).view(
            -1, 1
        )  # [sampler, 1]
```
This means that the initial input to the rollout storage should have the masks all be zero (so that hidden states to can be reset to whatever their default values are).