### PR TITLE
Excluding torch version 1.8.0 as it has a fatal bug in the `torch.mm` function.

### DIFF
--- a/allenact/setup.py
+++ b/allenact/setup.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         packages=find_packages(include=["allenact", "allenact.*"]),
         install_requires=[
             "gym>=0.17.0,<0.18.0",
-            "torch>=1.6.0",
+            "torch>=1.6.0,!=1.8.0",
             "tensorboardx>=2.1",
             "torchvision>=0.7.0",
             "setproctitle",

--- a/allenact_plugins/setup.py
+++ b/allenact_plugins/setup.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         packages=find_packages(include=["allenact_plugins", "allenact_plugins.*"]),
         install_requires=[
             "gym>=0.17.0,<0.18.0",
-            "torch>=1.6.0",
+            "torch>=1.6.0,!=1.8.0",
             "torchvision>=0.7.0",
             "numpy>=1.19.1",
             "wheel>=0.36.2",


### PR DESCRIPTION
@ekolve brought to my attention that `torch==1.8.0` has [a bug with the torch.mm function](https://github.com/pytorch/pytorch/issues/53336) and so I'm excluding this version explicitly.