### PR TITLE
Removing `class_action_names` as a required task method.

### DIFF
--- a/allenact/base_abstractions/task.py
+++ b/allenact/base_abstractions/task.py
@@ -15,6 +15,7 @@ from gym.spaces.dict import Dict as SpaceDict
 
 from allenact.base_abstractions.misc import RLStepResult
 from allenact.base_abstractions.sensor import Sensor, SensorSuite
+from allenact.utils.misc_utils import deprecated
 
 EnvType = TypeVar("EnvType")
 
@@ -104,8 +105,7 @@ class Task(Generic[EnvType]):
     def step(self, action: Any) -> RLStepResult:
         """Take an action in the environment (one per agent).
 
-        Takes the action in the environment corresponding to
-        `self.class_action_names()[action]` for each action if it's a Sequence and returns
+        Takes the action in the environment returns
         observations (& rewards and any additional information)
         corresponding to the agent's new state. Note that this function
         should not be overwritten without care (instead
@@ -113,7 +113,7 @@ class Task(Generic[EnvType]):
 
         # Parameters
 
-        action : The action to take.
+        action : The action to take, should be of the same form as specified by `self.action_space`.
 
         # Returns
 
@@ -144,8 +144,7 @@ class Task(Generic[EnvType]):
         """Helper function called by `step` to take a step by each agent in the
         environment.
 
-        Takes the action in the environment corresponding to
-        `self.class_action_names()[action]` for each action in actions and returns
+        Takes the action in the environment returns
         observations (& rewards and any additional information)
         corresponding to the agent's new state. This function is called
         by the (public) `step` function and is what should be implemented
@@ -184,39 +183,29 @@ class Task(Generic[EnvType]):
         """Number of steps taken by the agent in the task so far."""
         return self._num_steps_taken
 
-    @classmethod
-    @abc.abstractmethod
-    def class_action_names(cls, **kwargs) -> Tuple[str, ...]:
-        """A tuple of action names.
-
-        # Parameters
-
-        kwargs : Keyword arguments.
-
-        # Returns
-
-        Tuple of (ordered) action names so that taking action
-            running `task.step(i)` corresponds to taking action task.class_action_names()[i].
-        """
-        raise NotImplementedError()
-
+    @deprecated
     def action_names(self) -> Tuple[str, ...]:
         """Action names of the Task instance.
 
-        This method should be overwritten if `class_action_names`
+        This function has been deprecated and will be removed.
+
+        This function is a hold-over from when the `Task`
+        abstraction only considered `gym.space.Discrete` action spaces (in which
+        case it makes sense name these actions).
+
+        This implementation of `action_names` requires that a `class_action_names`
+        method has been defined. This method should be overwritten if `class_action_names`
         requires key word arguments to determine the number of actions.
         """
-        return self.class_action_names()
-
-    @property
-    def total_actions(self) -> int:
-        """Total number of actions available to an agent in this Task."""
-        return len(self.class_action_names())
-
-    def index_to_action(self, index: int) -> str:
-        """Returns the action name correspond to `index`."""
-        assert 0 <= index < self.total_actions
-        return self.class_action_names()[index]
+        if hasattr(self, "class_action_names"):
+            return self.class_action_names()
+        else:
+            raise NotImplementedError(
+                "`action_names` requires that a function `class_action_names` be defined."
+                " This said, please do not use this functionality as it has been deprecated and will be removed."
+                " If you would like an `action_names` function for your task, feel free to define one"
+                " with the knowledge that the AllenAct internals will ignore it."
+            )
 
     @abc.abstractmethod
     def close(self) -> None:

--- a/allenact/base_abstractions/task.py
+++ b/allenact/base_abstractions/task.py
@@ -105,7 +105,7 @@ class Task(Generic[EnvType]):
     def step(self, action: Any) -> RLStepResult:
         """Take an action in the environment (one per agent).
 
-        Takes the action in the environment returns
+        Takes the action in the environment and returns
         observations (& rewards and any additional information)
         corresponding to the agent's new state. Note that this function
         should not be overwritten without care (instead
@@ -144,7 +144,7 @@ class Task(Generic[EnvType]):
         """Helper function called by `step` to take a step by each agent in the
         environment.
 
-        Takes the action in the environment returns
+        Takes the action in the environment and returns
         observations (& rewards and any additional information)
         corresponding to the agent's new state. This function is called
         by the (public) `step` function and is what should be implemented

--- a/allenact/utils/misc_utils.py
+++ b/allenact/utils/misc_utils.py
@@ -68,6 +68,27 @@ def experimental_api(to_decorate):
     return decorated
 
 
+def deprecated(to_decorate):
+    """Decorate a function to note that it has been deprecated."""
+
+    have_warned = [False]
+    name = f"{inspect.getmodule(to_decorate).__name__}.{to_decorate.__qualname__}"
+    if to_decorate.__name__ == "__init__":
+        name = name.replace(".__init__", "")
+
+    @functools.wraps(to_decorate)
+    def decorated(*args, **kwargs):
+        if not have_warned[0]:
+            get_logger().warning(
+                f"'{name}' has been deprecated and will soon be removed from AllenAct's API."
+                f" Please discontinue your use of this function.",
+            )
+            have_warned[0] = True
+        return to_decorate(*args, **kwargs)
+
+    return decorated
+
+
 class NumpyJSONEncoder(json.JSONEncoder):
     """JSON encoder for numpy objects.
 

--- a/allenact/utils/system.py
+++ b/allenact/utils/system.py
@@ -21,7 +21,8 @@ _LOGGER: Optional[logging.Logger] = None
 class ColoredFormatter(logging.Formatter):
     """Format a log string with colors.
 
-    This implementation taken (with modifications) from https://stackoverflow.com/a/384125.
+    This implementation taken (with modifications) from
+    https://stackoverflow.com/a/384125.
     """
 
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
@@ -135,7 +136,7 @@ def _set_log_formatter():
     assert _LOGGER is not None
 
     if _LOGGER.getEffectiveLevel() <= logging.CRITICAL:
-        add_style_to_logs = True # In case someone wants to turn this off manually.
+        add_style_to_logs = True  # In case someone wants to turn this off manually.
 
         if add_style_to_logs:
             default_format = "$BOLD[%(asctime)s$RESET %(levelname)s$BOLD:]$RESET %(message)s\t[%(filename)s: %(lineno)d]"

--- a/allenact_plugins/habitat_plugin/habitat_tasks.py
+++ b/allenact_plugins/habitat_plugin/habitat_tasks.py
@@ -281,6 +281,9 @@ class ObjectNavTask(HabitatTask):
     def class_action_names(cls, **kwargs) -> Tuple[str, ...]:
         return cls._actions
 
+    def action_names(cls, **kwargs) -> Tuple[str, ...]:
+        return cls._actions
+
     def close(self) -> None:
         self.env.stop()
 

--- a/allenact_plugins/habitat_plugin/habitat_tasks.py
+++ b/allenact_plugins/habitat_plugin/habitat_tasks.py
@@ -281,8 +281,8 @@ class ObjectNavTask(HabitatTask):
     def class_action_names(cls, **kwargs) -> Tuple[str, ...]:
         return cls._actions
 
-    def action_names(cls, **kwargs) -> Tuple[str, ...]:
-        return cls._actions
+    def action_names(self, **kwargs) -> Tuple[str, ...]:
+        return self._actions
 
     def close(self) -> None:
         self.env.stop()

--- a/allenact_plugins/minigrid_plugin/minigrid_tasks.py
+++ b/allenact_plugins/minigrid_plugin/minigrid_tasks.py
@@ -314,7 +314,7 @@ class MiniGridTask(Task[CrossingEnv]):
             and self.corrupt_expert_within_actions_of_goal
             >= self.closest_agent_has_been_to_goal
         ):
-            return int(self.env.np_random.randint(0, len(self.action_names()))), True
+            return int(self.env.np_random.randint(0, len(self.class_action_names()))), True
 
         if len(paths[shortest_path_ind]) == 2:
             # Since "unified_goal" is 1 step away from actual goals

--- a/allenact_plugins/minigrid_plugin/minigrid_tasks.py
+++ b/allenact_plugins/minigrid_plugin/minigrid_tasks.py
@@ -314,7 +314,10 @@ class MiniGridTask(Task[CrossingEnv]):
             and self.corrupt_expert_within_actions_of_goal
             >= self.closest_agent_has_been_to_goal
         ):
-            return int(self.env.np_random.randint(0, len(self.class_action_names()))), True
+            return (
+                int(self.env.np_random.randint(0, len(self.class_action_names()))),
+                True,
+            )
 
         if len(paths[shortest_path_ind]) == 2:
             # Since "unified_goal" is 1 step away from actual goals

--- a/allenact_plugins/robothor_plugin/robothor_tasks.py
+++ b/allenact_plugins/robothor_plugin/robothor_tasks.py
@@ -90,7 +90,7 @@ class PointNavTask(Task[RoboThorEnvironment]):
         assert isinstance(action, int)
         action = cast(int, action)
 
-        action_str = self.action_names()[action]
+        action_str = self.class_action_names()[action]
 
         if action_str == END:
             self._took_end_action = True
@@ -236,7 +236,7 @@ class ObjectNavTask(Task[RoboThorEnvironment]):
 
         self.task_info["followed_path"] = [self.env.agent_state()]
         self.task_info["taken_actions"] = []
-        self.task_info["action_names"] = self.action_names()
+        self.task_info["action_names"] = self.class_action_names()
 
         if self._all_metadata_available:
             self.last_geodesic_distance = self.env.distance_to_object_type(
@@ -265,7 +265,7 @@ class ObjectNavTask(Task[RoboThorEnvironment]):
         assert isinstance(action, int)
         action = cast(int, action)
 
-        action_str = self.action_names()[action]
+        action_str = self.class_action_names()[action]
 
         if self.mirror:
             if action_str == ROTATE_RIGHT:
@@ -438,7 +438,7 @@ class ObjectNavTask(Task[RoboThorEnvironment]):
                         elif expert_action == "RotateRight":
                             expert_action = "RotateLeft"
 
-                    return self.action_names().index(expert_action), True
+                    return self.class_action_names().index(expert_action), True
                 else:
                     # This should have been caught by self._is_goal_in_range()...
                     return 0, False
@@ -476,7 +476,7 @@ class NavToPartnerTask(Task[RoboThorEnvironment]):
 
         self.task_info["followed_path1"] = [pose1]
         self.task_info["followed_path2"] = [pose2]
-        self.task_info["action_names"] = self.action_names()
+        self.task_info["action_names"] = self.class_action_names()
 
     @property
     def action_space(self):
@@ -501,8 +501,8 @@ class NavToPartnerTask(Task[RoboThorEnvironment]):
 
     def _step(self, action: Tuple[int, int]) -> RLStepResult:
         assert isinstance(action, tuple)
-        action_str1 = self.action_names()[action[0]]
-        action_str2 = self.action_names()[action[1]]
+        action_str1 = self.class_action_names()[action[0]]
+        action_str2 = self.class_action_names()[action[1]]
 
         self.env.step({"action": action_str1, "agentId": 0})
         self.last_action_success1 = self.env.last_action_success


### PR DESCRIPTION
As we used to always assume actions were `gym.spaces.Discrete` this meant it made sense to require tasks to name their actions via the `class_action_names` and `action_names` methods. Since actions can now be (practically) anything, this no longer makes much sense. To reflect this I've removed the `class_action_names` as a required abstract method. Tasks are still free to implement this method of course, we just won't require it anymore.