### PR TITLE
(Re-)Enabling early stopping criterions when performing non-distributed training.

### DIFF
--- a/allenact/algorithms/onpolicy_sync/losses/a2cacktr.py
+++ b/allenact/algorithms/onpolicy_sync/losses/a2cacktr.py
@@ -53,6 +53,11 @@ class A2CACKTR(AbstractActorCriticLoss):
         )
 
         dist_entropy: torch.FloatTensor = actor_critic_output.distributions.entropy()
+        dist_entropy = dist_entropy.view(
+            dist_entropy.shape
+            + ((1,) * (len(action_log_probs.shape) - len(dist_entropy.shape)))
+        )
+
         value_loss = 0.5 * (cast(torch.FloatTensor, batch["returns"]) - values).pow(2)
 
         # TODO: Decided not to use normalized advantages here,

--- a/allenact/algorithms/onpolicy_sync/losses/ppo.py
+++ b/allenact/algorithms/onpolicy_sync/losses/ppo.py
@@ -53,17 +53,23 @@ class PPO(AbstractActorCriticLoss):
 
         actions = cast(torch.LongTensor, batch["actions"])
         values = actor_critic_output.values
-        dist_entropy: torch.FloatTensor = actor_critic_output.distributions.entropy()
+
         action_log_probs = actor_critic_output.distributions.log_prob(actions)
+
+        dist_entropy: torch.FloatTensor = actor_critic_output.distributions.entropy()
+
+        def add_trailing_dims(t: torch.Tensor):
+            assert len(t.shape) <= len(batch["norm_adv_targ"].shape)
+            return t.view(
+                t.shape + ((1,) * (len(batch["norm_adv_targ"].shape) - len(t.shape)))
+            )
+
+        dist_entropy = add_trailing_dims(dist_entropy)
 
         clip_param = self.clip_param * self.clip_decay(step_count)
 
         ratio = torch.exp(action_log_probs - batch["old_action_log_probs"])
-        ratio = ratio.view(
-            ratio.shape
-            + (1,)
-            * (len(cast(torch.Tensor, batch["norm_adv_targ"]).shape) - len(ratio.shape))
-        )
+        ratio = add_trailing_dims(ratio)
 
         surr1 = ratio * batch["norm_adv_targ"]
         surr2 = (

--- a/allenact/algorithms/onpolicy_sync/runner.py
+++ b/allenact/algorithms/onpolicy_sync/runner.py
@@ -216,7 +216,7 @@ class OnPolicyRunner(object):
 
     @staticmethod
     def init_process(mode: str, id: int):
-        ptitle("{}-{}".format(mode, id))
+        ptitle(f"{mode}-{id}")
 
         def sigterm_handler(_signo, _stack_frame):
             raise KeyboardInterrupt
@@ -403,7 +403,7 @@ class OnPolicyRunner(object):
         checkpoint_path_dir_or_pattern: str,
         approx_ckpt_step_interval: Optional[Union[float, int]] = None,
         max_sampler_processes_per_worker: Optional[int] = None,
-    ):
+    ) -> List[Dict]:
         devices = self.worker_devices("test")
         self.init_visualizer("test")
         num_testers = len(devices)
@@ -411,6 +411,9 @@ class OnPolicyRunner(object):
         distributed_port = 0
         if num_testers > 1:
             distributed_port = find_free_port()
+
+        for k, q in self.queues.items():
+            assert q.empty(), f"{k} queue is not empty before starting test."
 
         for tester_it in range(num_testers):
             test: BaseProcess = self.mp_ctx.Process(
@@ -770,7 +773,7 @@ class OnPolicyRunner(object):
         nworkers: int,
         test_steps: Sequence[int] = (),
         metrics_file: Optional[str] = None,
-    ):
+    ) -> List[Dict]:
         finalized = False
 
         log_writer: Optional[SummaryWriter] = None

--- a/allenact/algorithms/onpolicy_sync/vector_sampled_tasks.py
+++ b/allenact/algorithms/onpolicy_sync/vector_sampled_tasks.py
@@ -33,7 +33,6 @@ from allenact.utils.misc_utils import partition_sequence
 from allenact.utils.system import get_logger
 from allenact.utils.tensor_utils import tile_images
 
-
 try:
     # Use torch.multiprocessing if we can.
     # We have yet to find a reason to not use it and
@@ -864,6 +863,8 @@ class SingleProcessVectorSampledTasks(object):
                     if current_task.is_done():
                         metrics = current_task.metrics()
                         if metrics is not None and len(metrics) != 0:
+                            if step_result.info is None:
+                                step_result = step_result.clone({"info": {}})
                             step_result.info[COMPLETE_TASK_METRICS_KEY] = metrics
 
                         if auto_resample_when_done:

--- a/allenact/algorithms/onpolicy_sync/vector_sampled_tasks.py
+++ b/allenact/algorithms/onpolicy_sync/vector_sampled_tasks.py
@@ -306,7 +306,7 @@ class VectorSampledTasks(object):
 
         except KeyboardInterrupt as e:
             if should_log:
-                get_logger().info("Worker {} KeyboardInterrupt".format(worker_id))
+                get_logger().info(f"Worker {worker_id} KeyboardInterrupt")
             raise e
         except Exception as e:
             get_logger().error(traceback.format_exc())
@@ -315,7 +315,7 @@ class VectorSampledTasks(object):
             if child_pipe is not None:
                 child_pipe.close()
             if should_log:
-                get_logger().info("""Worker {} closing.""".format(worker_id))
+                get_logger().info(f"Worker {worker_id} closing.")
 
     def _spawn_workers(
         self,
@@ -1086,8 +1086,11 @@ class SingleProcessVectorSampledTasks(object):
 
         for g in self._vector_task_generators:
             try:
-                g.send((CLOSE_COMMAND, None))
-            except StopIteration:
+                try:
+                    g.send((CLOSE_COMMAND, None))
+                except StopIteration:
+                    pass
+            except KeyboardInterrupt:
                 pass
 
         self._is_closed = True

--- a/allenact/base_abstractions/sensor.py
+++ b/allenact/base_abstractions/sensor.py
@@ -19,8 +19,8 @@ from typing import (
 
 import PIL
 import gym
-import numpy as np
 import gym.spaces as gyms
+import numpy as np
 from torch.distributions.utils import lazy_property
 from torchvision import transforms
 
@@ -236,7 +236,7 @@ class ExpertPolicySensor(Sensor[EnvType, SubTaskType]):
     ) -> None:
         self.nactions = nactions
         self.expert_args: Dict[str, Any] = expert_args or {}
-
+        observation_space = self._get_observation_space()
         super().__init__(**prepare_locals_for_super(locals()))
 
     def _get_observation_space(self) -> gym.spaces.Tuple:

--- a/allenact/embodiedai/models/basic_models.py
+++ b/allenact/embodiedai/models/basic_models.py
@@ -22,6 +22,7 @@ from allenact.algorithms.onpolicy_sync.policy import ActorCriticModel, Distribut
 from allenact.base_abstractions.distributions import CategoricalDistr
 from allenact.base_abstractions.misc import ActorCriticOutput, Memory
 from allenact.utils.model_utils import make_cnn, compute_cnn_output
+from allenact.utils.system import get_logger
 
 
 class SimpleCNN(nn.Module):
@@ -700,6 +701,26 @@ class RNNActorCritic(ActorCriticModel[CategoricalDistr]):
         prev_actions: torch.Tensor,
         masks: torch.FloatTensor,
     ) -> Tuple[ActorCriticOutput[DistributionType], Optional[Memory]]:
+
+        if self.memory_key not in memory:
+            get_logger().warning(
+                f"Key {self.memory_key} not found in memory,"
+                f" initializing this as all zeros."
+            )
+
+            obs = observations[self.input_uuid]
+            memory.check_append(
+                key=self.memory_key,
+                tensor=obs.new(
+                    self.num_recurrent_layers,
+                    obs.shape[1],
+                    self.recurrent_hidden_state_size,
+                )
+                .float()
+                .zero_(),
+                sampler_dim=1
+            )
+
         rnn_out, mem_return = self.state_encoder(
             x=observations[self.input_uuid],
             hidden_states=memory.tensor(self.memory_key),

--- a/allenact/main.py
+++ b/allenact/main.py
@@ -17,8 +17,8 @@ from allenact.base_abstractions.experiment_config import ExperimentConfig
 from allenact.utils.system import get_logger, init_logging, HUMAN_LOG_LEVELS
 
 
-def get_args():
-    """Creates the argument parser and parses any input arguments."""
+def get_argument_parser():
+    """Creates the argument parser."""
 
     # noinspection PyTypeChecker
     parser = argparse.ArgumentParser(
@@ -221,6 +221,13 @@ def get_args():
     )
     ### END DEPRECATED FLAGS
 
+    return parser
+
+
+def get_args():
+    """Creates the argument parser and parses any input arguments."""
+
+    parser = get_argument_parser()
     args = parser.parse_args()
 
     # check for deprecated
@@ -301,10 +308,11 @@ def load_config(args) -> Tuple[ExperimentConfig, Dict[str, str]]:
             sm for sm in all_sub_modules if desired_config_name in os.path.basename(sm)
         ]
         raise ModuleNotFoundError(
-            "Could not import experiment '{}', are you sure this is the right path?"
-            " Possibly relevant files include {}.".format(
-                module_path, relevant_submodules
-            ),
+            f"Could not import experiment '{module_path}', are you sure this is the right path?"
+            f" Possibly relevant files include {relevant_submodules}."
+            f" Note that the experiment must be reachable along your `PYTHONPATH`, it might"
+            f" be helpful for you to run `export PYTHONPATH=$PYTHONPATH:$PWD` in your"
+            f" project's top level directory."
         ) from e
 
     experiments = [

--- a/allenact/utils/system.py
+++ b/allenact/utils/system.py
@@ -78,13 +78,8 @@ def get_logger() -> logging.Logger:
     return _LOGGER
 
 
-def init_logging(human_log_level: str = "info") -> None:
-    """Init the `logging.Logger`.
+def _human_log_level_to_int(human_log_level):
 
-    It should be called only once in the app (e.g. in `main`). It sets
-    the log_level to one of `HUMAN_LOG_LEVELS`. And sets up a handler
-    for stderr. The logging level is propagated to all subprocesses.
-    """
     human_log_level = human_log_level.lower().strip()
     assert human_log_level in HUMAN_LOG_LEVELS, "unknown human_log_level {}".format(
         human_log_level
@@ -102,9 +97,22 @@ def init_logging(human_log_level: str = "info") -> None:
         log_level = logging.CRITICAL + 1
     else:
         raise NotImplementedError(f"Unknown log level {human_log_level}.")
+    return log_level
 
-    _new_logger(log_level)
+
+def init_logging(human_log_level: str = "info") -> None:
+    """Init the `logging.Logger`.
+
+    It should be called only once in the app (e.g. in `main`). It sets
+    the log_level to one of `HUMAN_LOG_LEVELS`. And sets up a handler
+    for stderr. The logging level is propagated to all subprocesses.
+    """
+    _new_logger(_human_log_level_to_int(human_log_level))
     _set_log_formatter()
+
+
+def update_log_level(logger, human_log_level: str):
+    logger.setLevel(_human_log_level_to_int(human_log_level))
 
 
 def find_free_port(address: str = "127.0.0.1") -> int:

--- a/allenact/utils/system.py
+++ b/allenact/utils/system.py
@@ -85,6 +85,7 @@ def init_logging(human_log_level: str = "info") -> None:
     the log_level to one of `HUMAN_LOG_LEVELS`. And sets up a handler
     for stderr. The logging level is propagated to all subprocesses.
     """
+    human_log_level = human_log_level.lower().strip()
     assert human_log_level in HUMAN_LOG_LEVELS, "unknown human_log_level {}".format(
         human_log_level
     )

--- a/allenact_plugins/lighthouse_plugin/lighthouse_util.py
+++ b/allenact_plugins/lighthouse_plugin/lighthouse_util.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Union
-
 import numpy as np
 
 from allenact.utils.experiment_utils import EarlyStoppingCriterion, ScalarMeanTracker
@@ -15,11 +13,7 @@ class StopIfNearOptimal(EarlyStoppingCriterion):
         self.memory: np.ndarray = np.zeros(min_memory_size)
 
     def __call__(
-        self,
-        stage_steps: int,
-        total_steps: int,
-        training_metrics: ScalarMeanTracker,
-        test_valid_metrics: List[Tuple[str, int, Union[float, np.ndarray]]],
+        self, stage_steps: int, total_steps: int, training_metrics: ScalarMeanTracker,
     ) -> bool:
         sums = training_metrics.sums()
         counts = training_metrics.counts()

--- a/docs/installation/installation-framework.md
+++ b/docs/installation/installation-framework.md
@@ -142,7 +142,8 @@ run the commands:
 ```bash
 export MY_ENV_NAME=allenact
 export CONDA_BASE="$(dirname $(dirname "${CONDA_EXE}"))"
-PIP_SRC="${CONDA_BASE}/envs/${MY_ENV_NAME}/pipsrc" conda env create --file ./conda/environment-base.yml --name $MY_ENV_NAME
+export PIP_SRC="${CONDA_BASE}/envs/${MY_ENV_NAME}/pipsrc"
+conda env create --file ./conda/environment-base.yml --name $MY_ENV_NAME
 ``` 
 
 These additional commands tell conda to place these dependencies under the `${CONDA_BASE}/envs/${MY_ENV_NAME}/pipsrc` directory rather


### PR DESCRIPTION
A project I'm working on benefits from being able to run many small experiments in order to do hyperparameter tuning. Towards enabling HP tuning, this PR re-enables early stopping criterions (a feature we removed when we introduced distributed training) in the case where distributed training is not used.