### PR TITLE
RoboTHOR -> iTHOR typos

### DIFF
--- a/projects/objectnav_baselines/experiments/ithor/objectnav_ithor_depth_resnetgru_ddppo.py
+++ b/projects/objectnav_baselines/experiments/ithor/objectnav_ithor_depth_resnetgru_ddppo.py
@@ -11,7 +11,7 @@ from projects.objectnav_baselines.experiments.objectnav_mixin_resnetgru import (
 )
 
 
-class ObjectNavRoboThorRGBPPOExperimentConfig(
+class ObjectNaviThorRGBPPOExperimentConfig(
     ObjectNaviThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInResNetGRUConfig,
 ):
     """An Object Navigation experiment configuration in iThor with Depth

--- a/projects/objectnav_baselines/experiments/ithor/objectnav_ithor_rgbd_resnetgru_ddppo.py
+++ b/projects/objectnav_baselines/experiments/ithor/objectnav_ithor_rgbd_resnetgru_ddppo.py
@@ -14,7 +14,7 @@ from projects.objectnav_baselines.experiments.objectnav_mixin_resnetgru import (
 )
 
 
-class ObjectNavRoboThorRGBPPOExperimentConfig(
+class ObjectNaviThorRGBPPOExperimentConfig(
     ObjectNaviThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInResNetGRUConfig
 ):
     """An Object Navigation experiment configuration in iThor with RGBD

--- a/projects/tutorials/pointnav_ithor_rgb_ddppo.py
+++ b/projects/tutorials/pointnav_ithor_rgb_ddppo.py
@@ -36,8 +36,8 @@ from projects.pointnav_baselines.models.point_nav_models import (
 )
 
 
-class ObjectNavRoboThorRGBPPOExperimentConfig(ExperimentConfig):
-    """A Point Navigation experiment configuration in RoboThor."""
+class PointNaviThorRGBPPOExperimentConfig(ExperimentConfig):
+    """A Point Navigation experiment configuration in iTHOR."""
 
     # Task Parameters
     MAX_STEPS = 500


### PR DESCRIPTION
iTHOR experiments looked to never have their docstrings or class names updated, presumably after being copied over from RoboTHOR.