### PR TITLE
Match AI2-THOR's step kwargs support

### DIFF
--- a/allenact_plugins/ithor_plugin/ithor_environment.py
+++ b/allenact_plugins/ithor_plugin/ithor_environment.py
@@ -639,7 +639,7 @@ class IThorEnvironment(object):
             )
 
     def step(
-        self, action_dict: Dict[str, Union[str, int, float]]
+        self, **action_dict: Dict[str, Union[str, int, float]]
     ) -> ai2thor.server.Event:
         """Take a step in the ai2thor environment."""
         action = cast(str, action_dict["action"])

--- a/allenact_plugins/robothor_plugin/robothor_environment.py
+++ b/allenact_plugins/robothor_plugin/robothor_environment.py
@@ -460,7 +460,7 @@ class RoboThorEnvironment:
         """
         return self.controller.last_event.metadata["actionReturn"]
 
-    def step(self, action_dict: Dict) -> ai2thor.server.Event:
+    def step(self, **action_dict: Dict) -> ai2thor.server.Event:
         """Take a step in the ai2thor environment."""
         return self.controller.step(**action_dict)
 


### PR DESCRIPTION
Currently when running the following in AllenAct
```python
self.env.step(...)
```
you have to pass in a dict:
```python
self.env.step(dict(action="MoveAhead", moveMagnitude=0.25))
```
Similar to AI2-THOR, this now allows for either a dict to be passed in (i.e., it's fully backwards compatible), or just the kwargs to be passed in, as in:
```python
self.env.step(action="MoveAhead", moveMagnitude=0.25)
```