### PR TITLE
manipulathor env: delete params before call ithor

### DIFF
--- a/allenact_plugins/manipulathor_plugin/manipulathor_environment.py
+++ b/allenact_plugins/manipulathor_plugin/manipulathor_environment.py
@@ -89,6 +89,8 @@ class ManipulaTHOREnvironment(IThorEnvironment):
         """
         self._verbose = verbose
         self.env_args = env_args
+        del verbose
+        del env_args
         super(ManipulaTHOREnvironment, self).__init__(
             **prepare_locals_for_super(locals())
         )


### PR DESCRIPTION
Thanks to @Lucaweihs, we fix this bug that caused the compile error.