### PR TITLE
Fix the typo of `pickup_success_reward` in armpointnav

### DIFF
--- a/projects/manipulathor_baselines/armpointnav_baselines/experiments/armpointnav_base.py
+++ b/projects/manipulathor_baselines/armpointnav_baselines/experiments/armpointnav_base.py
@@ -27,7 +27,7 @@ class ArmPointNavBaseConfig(ExperimentConfig, ABC):
         self.REWARD_CONFIG = {
             "step_penalty": -0.01,
             "goal_success_reward": 10.0,
-            "pickup_success_reward": 10.0,
+            "pickup_success_reward": 5.0,
             "failed_stop_reward": 0.0,
             "shaping_weight": 1.0,  # we are not using this
             "failed_action_penalty": -0.03,


### PR DESCRIPTION
According to the original paper https://arxiv.org/abs/2104.11213 and also confirmed by @ehsanik, the pickup success reward should be set as 5.0.