### PR TITLE
`config_kwargs` working in dmain (tested on Ubuntu 18)

### DIFF
--- a/scripts/dmain.py
+++ b/scripts/dmain.py
@@ -86,7 +86,9 @@ def get_raw_args():
             # Within backslash expansion: close former single, open double, create single, close double, reopen single
             inner_quote = r"\'\"\'\"\'"
             # Convert double quotes into backslash double for later expansion
-            filtered_args.append(inner_quote + arg.replace('"', r"\"") + inner_quote)
+            filtered_args.append(
+                inner_quote + arg.replace('"', r"\"").replace("'", r"\"") + inner_quote
+            )
             enclose_in_quotes = None
         elif arg in [
             "--runs_on",


### PR DESCRIPTION
`config_kwargs` featured in the [multi-node tutorial](https://allenact.org/tutorials/distributed-objectnav-tutorial/#run-your-experiment) doesn't work with the version of the dmain script in main. This commit fixes it by using a bash enhancement [enabling backslash escaping within single quotes](https://mywiki.wooledge.org/Quotes).