### PR TITLE
Self-supervised Aux Tasks in pointnav and objectnav

### DIFF
--- a/allenact/algorithms/onpolicy_sync/engine.py
+++ b/allenact/algorithms/onpolicy_sync/engine.py
@@ -1610,7 +1610,8 @@ class OnPolicyInference(OnPolicyRLEngine):
         frames: int = 0
         if verbose:
             get_logger().info(
-                f"[{self.mode}] worker {self.worker_id}: running evaluation on {num_tasks} tasks."
+                f"[{self.mode}] worker {self.worker_id}: running evaluation on {num_tasks} tasks"
+                f" for ckpt {checkpoint_file_path}"
             )
 
         if self.enforce_expert:
@@ -1665,6 +1666,7 @@ class OnPolicyInference(OnPolicyRLEngine):
                     )
                     get_logger().info(
                         f"[{self.mode}] worker {self.worker_id}:"
+                        f" for ckpt {checkpoint_file_path}"
                         f" {frames / (cur_time - init_time):.1f} fps,"
                         f" {npending}/{num_tasks} tasks pending ({lengths})."
                         f" ~{est_time_to_complete} min. to complete."

--- a/allenact/algorithms/onpolicy_sync/losses/ppo.py
+++ b/allenact/algorithms/onpolicy_sync/losses/ppo.py
@@ -26,8 +26,7 @@ class PPO(AbstractActorCriticLoss):
                           but we might use `conditional_entropy` for `SequentialDistr`
     show_ratios : If True, adds tracking for the PPO ratio (linear, clamped, and used) in each
                   epoch to be logged by the engine.
-    normalize_advantage: Whether or not to use normalized advantage. Default is False. 
-                        Caution: previously default is True.
+    normalize_advantage: Whether or not to use normalized advantage. Default is True.
     """
 
     def __init__(
@@ -38,7 +37,7 @@ class PPO(AbstractActorCriticLoss):
         use_clipped_value_loss=True,
         clip_decay: Optional[Callable[[int], float]] = None,
         entropy_method_name: str = "entropy",
-        normalize_advantage: bool = False,
+        normalize_advantage: bool = True,
         show_ratios: bool = False,
         *args,
         **kwargs

--- a/allenact/algorithms/onpolicy_sync/losses/ppo.py
+++ b/allenact/algorithms/onpolicy_sync/losses/ppo.py
@@ -26,6 +26,8 @@ class PPO(AbstractActorCriticLoss):
                           but we might use `conditional_entropy` for `SequentialDistr`
     show_ratios : If True, adds tracking for the PPO ratio (linear, clamped, and used) in each
                   epoch to be logged by the engine.
+    normalize_advantage: Whether or not to use normalized advantage. Default is False. 
+                        Caution: previously default is True.
     """
 
     def __init__(
@@ -36,6 +38,7 @@ class PPO(AbstractActorCriticLoss):
         use_clipped_value_loss=True,
         clip_decay: Optional[Callable[[int], float]] = None,
         entropy_method_name: str = "entropy",
+        normalize_advantage: bool = False,
         show_ratios: bool = False,
         *args,
         **kwargs
@@ -52,6 +55,10 @@ class PPO(AbstractActorCriticLoss):
         self.clip_decay = clip_decay if clip_decay is not None else (lambda x: 1.0)
         self.entropy_method_name = entropy_method_name
         self.show_ratios = show_ratios
+        if normalize_advantage:
+            self.adv_key = "norm_adv_targ"
+        else:
+            self.adv_key = "adv_targ"
 
     def loss_per_step(
         self,
@@ -71,9 +78,9 @@ class PPO(AbstractActorCriticLoss):
         )()
 
         def add_trailing_dims(t: torch.Tensor):
-            assert len(t.shape) <= len(batch["norm_adv_targ"].shape)
+            assert len(t.shape) <= len(batch[self.adv_key].shape)
             return t.view(
-                t.shape + ((1,) * (len(batch["norm_adv_targ"].shape) - len(t.shape)))
+                t.shape + ((1,) * (len(batch[self.adv_key].shape) - len(t.shape)))
             )
 
         dist_entropy = add_trailing_dims(dist_entropy)
@@ -84,8 +91,8 @@ class PPO(AbstractActorCriticLoss):
         ratio = add_trailing_dims(ratio)
         clamped_ratio = torch.clamp(ratio, 1.0 - clip_param, 1.0 + clip_param)
 
-        surr1 = ratio * batch["norm_adv_targ"]
-        surr2 = clamped_ratio * batch["norm_adv_targ"]
+        surr1 = ratio * batch[self.adv_key]
+        surr2 = clamped_ratio * batch[self.adv_key]
 
         use_clamped = surr2 < surr1
         action_loss = -torch.where(cast(torch.Tensor, use_clamped), surr2, surr1)

--- a/allenact/algorithms/onpolicy_sync/runner.py
+++ b/allenact/algorithms/onpolicy_sync/runner.py
@@ -81,7 +81,7 @@ class OnPolicyRunner(object):
         disable_config_saving: bool = False,
         distributed_ip_and_port: str = "127.0.0.1:0",
         machine_id: int = 0,
-        save_dir_fmt: SaveDirFormat = SaveDirFormat.FLAT,
+        save_dir_fmt: SaveDirFormat = SaveDirFormat.FLAT.value,
     ):
         self.config = config
         self.output_dir = output_dir
@@ -606,11 +606,11 @@ class OnPolicyRunner(object):
         for _ in range(num_testers):
             self.queues["checkpoints"].put(("quit", None))
 
-        if self.save_dir_fmt == SaveDirFormat.NESTED:
+        if self.save_dir_fmt == SaveDirFormat.NESTED.value:
             checkpoint_parts = self.checkpoint_log_folder_str(checkpoint_paths[0])
             metrics_dir = self.metric_path(self.local_start_time_str, checkpoint_parts)
             suffix = ""
-        elif self.save_dir_fmt == SaveDirFormat.FLAT:
+        elif self.save_dir_fmt == SaveDirFormat.FLAT.value:
             checkpoint_parts = None
             metrics_dir = self.metric_path(self.local_start_time_str)
             suffix = f"__test_{self.local_start_time_str}"
@@ -661,16 +661,16 @@ class OnPolicyRunner(object):
             else os.path.join(self.config.tag(), self.extra_tag),
             start_time_str or self.local_start_time_str,
         ]
-        if self.save_dir_fmt == SaveDirFormat.NESTED:
+        if self.save_dir_fmt == SaveDirFormat.NESTED.value:
             folder = os.path.join(self.output_dir, *path_parts, "checkpoints",)
-        elif self.save_dir_fmt == SaveDirFormat.FLAT:
+        elif self.save_dir_fmt == SaveDirFormat.FLAT.value:
             folder = os.path.join(self.output_dir, "checkpoints", *path_parts,)
         if create_if_none:
             os.makedirs(folder, exist_ok=True)
         return folder
 
     def log_writer_path(self, start_time_str: str, checkpoint_parts: List = []) -> str:
-        if self.save_dir_fmt == SaveDirFormat.NESTED:
+        if self.save_dir_fmt == SaveDirFormat.NESTED.value:
             if self.mode == TEST_MODE_STR:
                 return os.path.join(
                     *checkpoint_parts,
@@ -687,7 +687,7 @@ class OnPolicyRunner(object):
                 "train_tb",
             )
             return path
-        elif self.save_dir_fmt == SaveDirFormat.FLAT:
+        elif self.save_dir_fmt == SaveDirFormat.FLAT.value:
             path = os.path.join(
                 self.output_dir,
                 "tb",
@@ -701,11 +701,11 @@ class OnPolicyRunner(object):
             return path
 
     def metric_path(self, start_time_str: str, checkpoint_parts: List = []) -> str:
-        if self.save_dir_fmt == SaveDirFormat.NESTED:
+        if self.save_dir_fmt == SaveDirFormat.NESTED.value:
             return os.path.join(
                 *checkpoint_parts, "test", self.config.tag(), start_time_str,
             )
-        elif self.save_dir_fmt == SaveDirFormat.FLAT:
+        elif self.save_dir_fmt == SaveDirFormat.FLAT.value:
             return os.path.join(
                 self.output_dir,
                 "metrics",
@@ -722,9 +722,9 @@ class OnPolicyRunner(object):
             else os.path.join(self.config.tag(), self.extra_tag),
             self.local_start_time_str,
         ]
-        if self.save_dir_fmt == SaveDirFormat.NESTED:
+        if self.save_dir_fmt == SaveDirFormat.NESTED.value:
             base_dir = os.path.join(self.output_dir, *path_parts, "used_configs",)
-        elif self.save_dir_fmt == SaveDirFormat.FLAT:
+        elif self.save_dir_fmt == SaveDirFormat.FLAT.value:
             base_dir = os.path.join(self.output_dir, "used_configs", *path_parts,)
         os.makedirs(base_dir, exist_ok=True)
 

--- a/allenact/algorithms/onpolicy_sync/runner.py
+++ b/allenact/algorithms/onpolicy_sync/runner.py
@@ -52,10 +52,13 @@ from allenact.utils.viz_utils import VizSuite
 
 _CONFIG_KWARGS_STR = "__CONFIG_KWARGS__"
 
+
 class SaveDirFormat(enum.Enum):
     """Directory formats that can be used when saving tensorboard logs, checkpoints, etc. during training/evaluation."""
+
     FLAT = "FLAT"
     NESTED = "NESTED"
+
 
 # Has results queue (aggregated per trainer), checkpoints queue and mp context
 # Instantiates train, validate, and test workers
@@ -653,28 +656,20 @@ class OnPolicyRunner(object):
         self, start_time_str: Optional[str] = None, create_if_none: bool = True
     ):
         path_parts = [
-                self.config.tag()
-                if self.extra_tag == ""
-                else os.path.join(self.config.tag(), self.extra_tag),
-                start_time_str or self.local_start_time_str,
+            self.config.tag()
+            if self.extra_tag == ""
+            else os.path.join(self.config.tag(), self.extra_tag),
+            start_time_str or self.local_start_time_str,
         ]
         if self.save_dir_fmt == SaveDirFormat.NESTED:
-            folder = os.path.join(
-                self.output_dir,
-                *path_parts,
-                "checkpoints",
-            )
+            folder = os.path.join(self.output_dir, *path_parts, "checkpoints",)
         elif self.save_dir_fmt == SaveDirFormat.FLAT:
-            folder = os.path.join(
-                self.output_dir,
-                "checkpoints",
-                *path_parts,
-            )
+            folder = os.path.join(self.output_dir, "checkpoints", *path_parts,)
         if create_if_none:
             os.makedirs(folder, exist_ok=True)
         return folder
 
-    def log_writer_path(self, start_time_str: str, checkpoint_parts: List=[]) -> str:
+    def log_writer_path(self, start_time_str: str, checkpoint_parts: List = []) -> str:
         if self.save_dir_fmt == SaveDirFormat.NESTED:
             if self.mode == TEST_MODE_STR:
                 return os.path.join(
@@ -728,17 +723,9 @@ class OnPolicyRunner(object):
             self.local_start_time_str,
         ]
         if self.save_dir_fmt == SaveDirFormat.NESTED:
-            base_dir = os.path.join(
-                self.output_dir,
-                *path_parts,
-                "used_configs",
-            )
+            base_dir = os.path.join(self.output_dir, *path_parts, "used_configs",)
         elif self.save_dir_fmt == SaveDirFormat.FLAT:
-            base_dir = os.path.join(
-                self.output_dir,
-                "used_configs",
-                *path_parts,
-            )
+            base_dir = os.path.join(self.output_dir, "used_configs", *path_parts,)
         os.makedirs(base_dir, exist_ok=True)
 
         # Saving current git diff

--- a/allenact/embodiedai/aux_losses/losses.py
+++ b/allenact/embodiedai/aux_losses/losses.py
@@ -1,0 +1,455 @@
+"""Defining the auxiliary loss for actor critic type models."""
+
+from typing import Dict, cast, Tuple, List
+import abc
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from allenact.algorithms.onpolicy_sync.losses.abstract_loss import (
+    AbstractActorCriticLoss,
+    ObservationType,
+)
+from allenact.base_abstractions.distributions import CategoricalDistr
+from allenact.base_abstractions.misc import ActorCriticOutput
+
+def subsampled_masks(masks, p=0.1):
+    return (torch.rand_like(masks) <= p).float()
+
+class TaskWeightsLoss(AbstractActorCriticLoss):
+    UUID = 'task_weights' # make sure its uniqueness
+
+    def __init__(self, task_names: List[str], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_tasks = len(task_names)
+        self.task_names = task_names
+
+    def loss(  # type: ignore
+        self,
+        step_count: int,
+        batch: ObservationType,
+        actor_critic_output: ActorCriticOutput[CategoricalDistr],
+        *args,
+        **kwargs
+    ) -> Tuple[torch.FloatTensor, Dict[str, float]]:
+        task_weights = actor_critic_output.extras[self.UUID]
+        task_weights = task_weights.view(-1, self.num_tasks)
+        entropy = CategoricalDistr(task_weights).entropy()
+
+        avg_loss = (-entropy).mean()
+        avg_task_weights = task_weights.mean(dim=0) # (K)
+
+        outputs = dict()
+        outputs["entropy_loss"] = cast(torch.Tensor, avg_loss).item()
+        for i in range(self.num_tasks):
+            outputs["weight_" + self.task_names[i]] = cast(
+                    torch.Tensor, avg_task_weights[i]).item()
+        
+        return (
+            avg_loss,
+            outputs,
+        )
+
+
+
+class AuxiliaryLoss(AbstractActorCriticLoss):
+    def __init__(self, auxiliary_uuid: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.auxiliary_uuid = auxiliary_uuid
+
+    def loss(  # type: ignore
+        self,
+        step_count: int,
+        batch: ObservationType,
+        actor_critic_output: ActorCriticOutput[CategoricalDistr],
+        *args,
+        **kwargs
+    ) -> Tuple[torch.FloatTensor, Dict[str, float]]:
+
+        # auxiliary loss
+        return self.get_aux_loss(
+            **actor_critic_output.extras[self.auxiliary_uuid],
+            observations=batch["observations"],
+            actions=batch["actions"],
+            masks=batch["masks"],
+            rewards=batch["rewards"],
+        )
+
+    @abc.abstractmethod
+    def get_aux_loss(
+        self,
+        aux_model: nn.Module,
+        observations: ObservationType,
+        obs_embeds: torch.FloatTensor,
+        actions: torch.FloatTensor,
+        beliefs: torch.FloatTensor,
+        masks: torch.FloatTensor,
+        rewards: torch.FloatTensor,
+        *args,
+        **kwargs
+    ):
+        raise NotImplementedError()
+
+
+class InverseDynamicsLoss(AuxiliaryLoss):
+    UUID = "InvDyn"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, subsample_min_num: int = 10, *args, **kwargs
+    ):
+        super().__init__(auxiliary_uuid=self.UUID, *args, **kwargs)
+
+        self.cross_entropy_loss = nn.CrossEntropyLoss(reduction="none")
+        self.subsample_rate = subsample_rate
+        self.subsample_min_num = subsample_min_num
+
+    def get_aux_loss(
+        self,
+        aux_model: nn.Module,
+        observations: ObservationType,
+        obs_embeds: torch.FloatTensor,
+        actions: torch.FloatTensor,
+        beliefs: torch.FloatTensor,
+        masks: torch.FloatTensor,
+        *args,
+        **kwargs
+    ):
+        ## we discard the last action in the batch
+        num_steps, num_sampler = actions.shape  # T, B
+        actions = cast(torch.LongTensor, actions)
+        actions = actions[:-1]  # (T-1, B)
+
+        ## find the final belief state based on masks
+        # we did not compute loss here cuz model.forward is compute-heavy
+        masks = masks.squeeze(-1)  # (T, B)
+        final_beliefs = torch.zeros_like(beliefs)  # (T, B, *)
+        for i in range(num_sampler):
+            # right shift: to locate the 1 before 0 and ignore the 1st element
+            end_locs = torch.where(masks[1:, i] == 0)[0]  # maybe [], dtype=torch.Long
+            
+            start_locs = torch.cat(
+                [torch.tensor([0]).to(end_locs), end_locs + 1]
+            )  # add the first element
+
+            end_locs = torch.cat(
+                [end_locs, torch.tensor([num_steps - 1]).to(end_locs)]
+            )  # add the last element
+
+            for st, ed in zip(start_locs, end_locs):
+                final_beliefs[st: ed + 1, i] = beliefs[ed, i]
+
+        ## compute CE loss
+        decoder_in = torch.cat(
+            [obs_embeds[:-1], obs_embeds[1:], final_beliefs[:-1]], dim=2
+        )  # (T-1, B, *)
+
+        preds = aux_model(decoder_in)  # (T-1, B, A)
+        # cross entropy loss require class dim at 1
+        loss = self.cross_entropy_loss(
+            preds.view((num_steps - 1) * num_sampler, -1),  # ((T-1)*B, A)
+            actions.flatten(),  #  ((T-1)*B,)
+        )
+        loss = loss.view(num_steps - 1, num_sampler) # (T-1, B)
+
+        def vanilla_valid_losses(loss, num_sampler, end_locs_batch):
+            ##  this is just used to verify the vectorized version works correctly.
+            ##  not used for experimentation
+            valid_losses = []
+            for i in range(num_sampler):
+                end_locs = end_locs_batch[i]
+                for j in range(len(end_locs)):
+                    if j == 0:
+                        start_loc = 0
+                    else:
+                        start_loc = end_locs[j - 1] + 1
+                    end_loc = end_locs[j]
+                    if end_loc - start_loc <= 0:  # the episode only 1-step
+                        continue
+                    valid_losses.append(loss[start_loc:end_loc, i])
+
+            if len(valid_losses) == 0:
+                valid_losses = torch.zeros(1, dtype=torch.float).to(loss)
+            else:
+                valid_losses = torch.cat(valid_losses)  # (sum m, )
+            return valid_losses
+
+        # valid_losses = masks[1:] * loss # (T-1, B)
+        # valid_losses0 = vanilla_valid_losses(loss, num_sampler, end_locs_batch)
+        # assert valid_losses0.sum() == valid_losses.sum()
+
+        num_valid_losses = torch.count_nonzero(masks[1:])
+        if num_valid_losses < self.subsample_min_num:  # don't subsample
+            subsample_rate = 1.0
+        else:
+            subsample_rate = self.subsample_rate
+
+        loss_masks = masks[1:] * subsampled_masks(masks[1:], subsample_rate)
+        num_valid_losses = torch.count_nonzero(loss_masks)
+        avg_loss = (loss * loss_masks).sum() / torch.clamp(num_valid_losses, min=1.0)
+
+        return (
+            avg_loss,
+            {"total": cast(torch.Tensor, avg_loss).item(),},
+        )
+
+class TemporalDistanceLoss(AuxiliaryLoss):
+    UUID = "TempDist"
+
+    def __init__(
+        self, num_pairs: int = 8, epsiode_len_min: int = 5, *args, **kwargs
+    ):
+        super().__init__(auxiliary_uuid=self.UUID, *args, **kwargs)
+        self.num_pairs = num_pairs
+        self.epsiode_len_min = float(epsiode_len_min)
+
+    def get_aux_loss(
+        self,
+        aux_model: nn.Module,
+        observations: ObservationType,
+        obs_embeds: torch.FloatTensor,
+        actions: torch.FloatTensor,
+        beliefs: torch.FloatTensor,
+        masks: torch.FloatTensor,
+        *args,
+        **kwargs
+    ):
+        ## we discard the last action in the batch
+        num_steps, num_sampler = actions.shape  # T, B
+        actions = cast(torch.LongTensor, actions)
+        actions = actions[:-1]  # (T-1, B)
+
+        ## find the final belief state based on masks
+        # we did not compute loss here cuz model.forward is compute-heavy
+        masks = masks.squeeze(-1)  # (T, B)
+        final_beliefs = torch.zeros_like(beliefs)  # (T, B, *)
+
+        ## also find the locs_batch of shape (M, 3)
+        # the last dim: [0] is on num_sampler loc, [1] and [2] is start and end locs
+        # of one episode
+        # in other words: at locs_batch[m, 0] in num_sampler dim, there exists one episode
+        # starting from locs_batch[m, 1], ends at locs_batch[m, 2] (included)
+        locs_batch = []
+
+        for i in range(num_sampler):
+            # right shift: to locate the 1 before 0 and ignore the 1st element
+            end_locs = torch.where(masks[1:, i] == 0)[0]  # maybe [], dtype=torch.Long
+            
+            start_locs = torch.cat(
+                [torch.tensor([0]).to(end_locs), end_locs + 1]
+            )  # add the first element
+
+            end_locs = torch.cat(
+                [end_locs, torch.tensor([num_steps - 1]).to(end_locs)]
+            )  # add the last element
+
+            locs_batch.append(torch.stack([
+                i * torch.ones_like(start_locs), start_locs, end_locs
+            ], dim=-1)) # shape (M[i], 3)
+
+            for st, ed in zip(start_locs, end_locs):
+                final_beliefs[st: ed + 1, i] = beliefs[ed, i]
+        
+        locs_batch = torch.cat(locs_batch) # shape (M, 3)
+        temporal_dist_max = (locs_batch[:, 2] - locs_batch[:, 1]).float() # end - start, (M)
+        # create normalizer that ignores too short episode, otherwise 1/T
+        normalizer = torch.where(temporal_dist_max > self.epsiode_len_min,
+                        1.0 / temporal_dist_max, torch.tensor([0]).to(temporal_dist_max)) # (M)
+
+        # sample validpairs: sampled_pairs shape (M, num_pairs, 3)
+        # where M is the num of total episodes in the batch
+        locs = locs_batch.cpu().numpy() # cuz torch.randint only support int, not tensor
+        sampled_pairs = np.random.randint(
+            np.repeat(locs[:,[1]],     2*self.num_pairs, axis=-1), # (M, 2*k)
+            np.repeat(locs[:,[2]] + 1, 2*self.num_pairs, axis=-1), # (M, 2*k)
+        ).reshape(-1, self.num_pairs, 2) # (M, k, 2)
+        sampled_pairs_batch = torch.from_numpy(sampled_pairs).to(locs_batch) # (M, k, 2)
+
+        num_sampler_batch = locs_batch[:, [0]].expand(-1, 2*self.num_pairs) # (M, 1) -> (M, 2*k)
+        num_sampler_batch = num_sampler_batch.reshape(-1, self.num_pairs, 2) # (M, k, 2)
+
+        sampled_obs_embeds = obs_embeds[sampled_pairs_batch, num_sampler_batch] # (M, k, 2, H1)
+        sampled_final_beliefs = final_beliefs[sampled_pairs_batch, num_sampler_batch] # (M, k, 2, H2)
+        features = torch.cat([
+            sampled_obs_embeds[:, :, 0], sampled_obs_embeds[:, :, 1], 
+            sampled_final_beliefs[:, :, 0]
+        ], dim=-1) # (M, k, 2*H1 + H2)
+        
+        pred_temp_dist = aux_model(features).squeeze(-1) # (M, k)
+        true_temp_dist = (sampled_pairs_batch[:, :, 1] - sampled_pairs_batch[:, :, 0]).float() # (M, k)
+
+        pred_error = (pred_temp_dist - true_temp_dist) * normalizer.unsqueeze(1)
+        loss = 0.5 * (pred_error).pow(2)
+        avg_loss = loss.mean()
+
+        return (
+            avg_loss,
+            {"total": cast(torch.Tensor, avg_loss).item(),},
+        )
+
+class CPCALoss(AuxiliaryLoss):
+    UUID = "CPCA"
+
+    def __init__(
+        self, planning_steps: int = 8, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(auxiliary_uuid=self.UUID, *args, **kwargs)
+        self.planning_steps = planning_steps
+        self.subsample_rate= subsample_rate
+        self.cross_entropy_loss = nn.BCEWithLogitsLoss(reduction="none")
+
+    def get_aux_loss(
+        self,
+        aux_model: nn.Module,
+        observations: ObservationType,
+        obs_embeds: torch.FloatTensor,
+        actions: torch.FloatTensor,
+        beliefs: torch.FloatTensor,
+        masks: torch.FloatTensor,
+        *args,
+        **kwargs
+    ):
+        # prepare for autoregressive inputs: c_{t+1:t+k} = GRU(b_t, a_{t:t+k-1}) <-> z_{t+k}
+        ## where b_t = RNN(b_{t-1}, z_t, a_{t-1}), prev action is optional
+        num_steps, num_sampler, obs_embed_size = obs_embeds.shape  # T, N, H_O
+        assert 0 < self.planning_steps <= num_steps
+        
+        ## prepare positive and negatives that sample from all the batch
+        positives = obs_embeds # (T, N, -1)
+        negative_inds = torch.randperm(num_steps*num_sampler).to(positives.device)
+        negatives = torch.gather( # input[index[i,j]][j]
+            positives.view(num_steps*num_sampler, -1),
+            dim=0,
+            index=negative_inds.view(num_steps*num_sampler, 1).expand(num_steps*num_sampler, positives.size(-1)),
+        ).view(num_steps, num_sampler, -1) # (T, N, -1)
+
+        ## prepare action sequences and initial beliefs
+        action_embedding = aux_model.action_embedder(actions) # (T, N, -1)
+        action_embed_size = action_embedding.size(-1)
+        action_padding = torch.zeros(self.planning_steps - 1, num_sampler, action_embed_size).to(action_embedding) # (k-1, N, -1)
+        action_padded = torch.cat((action_embedding, action_padding), dim=0) # (T+k-1, N, -1)
+        ## unfold function will create consecutive action sequences
+        action_seq = action_padded.unfold(dimension=0, size=self.planning_steps, step=1).permute(3, 0, 1, 2).view(
+                                self.planning_steps, num_steps*num_sampler, action_embed_size) # (k, T*N, -1)
+        beliefs = beliefs.view(num_steps*num_sampler, -1).unsqueeze(0) # (1, T*N, -1)
+
+        # get future contexts c_{t+1:t+k} = GRU(b_t, a_{t:t+k-1})
+        future_contexts_all, _ = aux_model.context_model(action_seq, beliefs) # (k, T*N, -1) 
+        ## NOTE: future_contexts_all starting from next step t+1 to t+k, not t to t+k-1
+        future_contexts_all = future_contexts_all.view(
+                                self.planning_steps, num_steps, num_sampler, -1).permute(1, 0, 2, 3) # (k, T, N, -1) 
+
+        # get all the classifier scores I(c_{t+1:t+k}; z_{t+1:t+k})
+        positives_padding = torch.zeros(self.planning_steps, num_sampler, obs_embed_size).to(positives) # (k, N, -1)
+        positives_padded = torch.cat((positives[1:], positives_padding), dim=0) # (T+k-1, N, -1)
+        positives_expanded = positives_padded.unfold(dimension=0, size=self.planning_steps, step=1).permute(0, 3, 1, 2) # (T, k, N, -1)
+        positives_logits = aux_model.classifier(torch.cat([positives_expanded, future_contexts_all], -1)) # (T, k, N, 1)
+        positive_loss = self.cross_entropy_loss(positives_logits, torch.ones_like(positives_logits)) # (T, k, N, 1)
+
+        negatives_padding = torch.zeros(self.planning_steps, num_sampler, obs_embed_size).to(negatives) # (k, N, -1)
+        negatives_padded = torch.cat((negatives[1:], negatives_padding), dim=0) # (T+k-1, N, -1)
+        negatives_expanded = negatives_padded.unfold(dimension=0, size=self.planning_steps, step=1).permute(0, 3, 1, 2) # (T, k, N, -1)
+        negatives_logits = aux_model.classifier(torch.cat([negatives_expanded, future_contexts_all], -1)) # (T, k, N, 1)
+        negative_loss = self.cross_entropy_loss(negatives_logits, torch.zeros_like(negatives_logits)) # (T, k, N, 1)
+
+        # Masking to get valid scores
+        ## masks: Note which timesteps [1, T+k+1] could have valid queries, at distance (k) (note offset by 1)
+        ## we will extract the **diagonals** as valid_masks from masks later as below
+        ## the vertical axis is (absolute) real timesteps, the horizontal axis is (relative) planning timesteps
+        ## | - - - - - |
+        ## | .         |
+        ## | , .       |
+        ## | . , .     |
+        ## | , . , .   |
+        ## |   , . , . |
+        ## |     , . , |
+        ## |       , . |
+        ## |         , |
+        ## | - - - - - |
+        masks = masks.squeeze(-1)  # (T, N)
+        pred_masks = torch.ones(
+            num_steps + self.planning_steps, self.planning_steps, num_sampler, 1, dtype=torch.bool
+        ).to(beliefs.device) # (T+k, k, N, 1)
+
+        pred_masks[num_steps - 1:] = False # GRU(b_t, a_{t:t+k-1}) is invalid when t >= T, cuz we don't have real z_{t+1}
+        for j in range(1, self.planning_steps + 1): # for j-step predictions
+            pred_masks[:j - 1, j - 1] = False # Remove the upper triangle above the diagnonal (but I think this is unnecessary for valid_masks)
+            for n in range(num_sampler):
+                has_zeros_batch = torch.where(masks[:, n] == 0)[0]
+                # in j-step prediction, timesteps z -> z + j are disallowed as those are the first j timesteps of a new episode
+                # z-> z-1 because of pred_masks being offset by 1
+                for z in has_zeros_batch:
+                    pred_masks[z-1: z-1 + j, j - 1, n] = False # can affect j timesteps
+
+        # instead of the whole range, we actually are only comparing a window i:i+k for each query/target i - for each, select the appropriate k
+        # we essentially gather diagonals from this full mask, t of them, k long
+        valid_diagonals = [torch.diagonal(pred_masks, offset=-i) for i in range(num_steps)] # pull the appropriate k per timestep
+        valid_masks = torch.stack(valid_diagonals, dim=0).permute(0, 3, 1, 2).float() # (T, N, 1, k) -> (T, k, N, 1)
+        # print(valid_masks.int().squeeze(-1)); print(masks) # verify its correctness
+
+        loss_masks = valid_masks * subsampled_masks(valid_masks, self.subsample_rate) # (T, k, N, 1)
+        num_valid_losses = torch.count_nonzero(loss_masks)
+        avg_positive_loss = (positive_loss * loss_masks).sum() / torch.clamp(num_valid_losses, min=1.0)
+        avg_negative_loss = (negative_loss * loss_masks).sum() / torch.clamp(num_valid_losses, min=1.0)
+
+        avg_loss = avg_positive_loss + avg_negative_loss
+
+        return (
+            avg_loss,
+            {"total": cast(torch.Tensor, avg_loss).item(),
+            "positive_loss": cast(torch.Tensor, avg_positive_loss).item(),
+            "negative_loss": cast(torch.Tensor, avg_negative_loss).item(),
+            },
+        )
+
+class CPCA1Loss(CPCALoss):
+    UUID = "CPCA_1"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(planning_steps=1, 
+            subsample_rate=subsample_rate, *args, **kwargs
+        )
+
+class CPCA2Loss(CPCALoss):
+    UUID = "CPCA_2"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(planning_steps=2, 
+            subsample_rate=subsample_rate, *args, **kwargs
+        )
+
+class CPCA4Loss(CPCALoss):
+    UUID = "CPCA_4"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(planning_steps=4, 
+            subsample_rate=subsample_rate, *args, **kwargs
+        )
+
+class CPCA8Loss(CPCALoss):
+    UUID = "CPCA_8"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(planning_steps=8, 
+            subsample_rate=subsample_rate, *args, **kwargs
+        )
+
+class CPCA16Loss(CPCALoss):
+    UUID = "CPCA_16"
+
+    def __init__(
+        self, subsample_rate: float = 0.2, *args, **kwargs
+    ):
+        super().__init__(planning_steps=16, 
+            subsample_rate=subsample_rate, *args, **kwargs
+        )

--- a/allenact/embodiedai/aux_losses/losses.py
+++ b/allenact/embodiedai/aux_losses/losses.py
@@ -77,7 +77,6 @@ class AuxiliaryLoss(AbstractActorCriticLoss):
             observations=batch["observations"],
             actions=batch["actions"],
             masks=batch["masks"],
-            rewards=batch["rewards"],
         )
 
     @abc.abstractmethod
@@ -89,7 +88,6 @@ class AuxiliaryLoss(AbstractActorCriticLoss):
         actions: torch.FloatTensor,
         beliefs: torch.FloatTensor,
         masks: torch.FloatTensor,
-        rewards: torch.FloatTensor,
         *args,
         **kwargs
     ):

--- a/allenact/embodiedai/aux_losses/losses.py
+++ b/allenact/embodiedai/aux_losses/losses.py
@@ -1,4 +1,13 @@
-"""Defining the auxiliary loss for actor critic type models."""
+# Original work Copyright (c) Facebook, Inc. and its affiliates.
+# Modified work Copyright (c) Allen Institute for AI
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Defining the auxiliary loss for actor critic type models.
+
+Several of the losses defined in this file are modified versions of those found in 
+    https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+"""
+
 
 from typing import Dict, cast, Tuple, List
 import abc
@@ -16,12 +25,16 @@ from allenact.base_abstractions.distributions import CategoricalDistr
 from allenact.base_abstractions.misc import ActorCriticOutput
 
 
-def subsampled_masks(masks, p=0.1):
+def _bernoulli_subsample_mask_like(masks, p=0.1):
     return (torch.rand_like(masks) <= p).float()
 
 
-class TaskWeightsLoss(AbstractActorCriticLoss):
-    UUID = "task_weights"  # make sure its uniqueness
+class MultiAuxTaskNegEntropyLoss(AbstractActorCriticLoss):
+    '''
+    Used in multiple auxiliary tasks setting.
+    Add a negative entropy loss over all the task weights.
+    '''
+    UUID = "multitask_entropy"  # make sure this is unique
 
     def __init__(self, task_names: List[str], *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -43,8 +56,7 @@ class TaskWeightsLoss(AbstractActorCriticLoss):
         avg_loss = (-entropy).mean()
         avg_task_weights = task_weights.mean(dim=0)  # (K)
 
-        outputs = dict()
-        outputs["entropy_loss"] = cast(torch.Tensor, avg_loss).item()
+        outputs = {"entropy_loss": cast(torch.Tensor, avg_loss).item()}
         for i in range(self.num_tasks):
             outputs["weight_" + self.task_names[i]] = cast(
                 torch.Tensor, avg_task_weights[i]
@@ -57,6 +69,11 @@ class TaskWeightsLoss(AbstractActorCriticLoss):
 
 
 class AuxiliaryLoss(AbstractActorCriticLoss):
+    '''
+    Base class of auxiliary loss. 
+    Any auxiliary task loss should inherit from it, and implement
+        the `get_aux_loss` function.
+    '''
     def __init__(self, auxiliary_uuid: str, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -94,12 +111,46 @@ class AuxiliaryLoss(AbstractActorCriticLoss):
         raise NotImplementedError()
 
 
+def _propagate_final_beliefs_to_all_steps(
+    beliefs: torch.Tensor, masks: torch.Tensor, num_sampler: int, num_steps: int,
+):
+    final_beliefs = torch.zeros_like(beliefs) # (T, B, *)
+    start_locs_list = []
+    end_locs_list = []
+
+    for i in range(num_sampler):
+        # right shift: to locate the 1 before 0 and ignore the 1st element
+        end_locs = torch.where(masks[1:, i] == 0)[0]  # maybe [], dtype=torch.Long
+
+        start_locs = torch.cat(
+            [torch.tensor([0]).to(end_locs), end_locs + 1]
+        )  # add the first element
+        start_locs_list.append(start_locs)
+
+        end_locs = torch.cat(
+            [end_locs, torch.tensor([num_steps - 1]).to(end_locs)]
+        )  # add the last element
+        end_locs_list.append(end_locs)
+
+        for st, ed in zip(start_locs, end_locs):
+            final_beliefs[st : ed + 1, i] = beliefs[ed, i]
+    
+    return final_beliefs, start_locs_list, end_locs_list
+
 class InverseDynamicsLoss(AuxiliaryLoss):
+    '''
+    Auxiliary task of Inverse Dynamics 
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+    '''
     UUID = "InvDyn"
 
     def __init__(
         self, subsample_rate: float = 0.2, subsample_min_num: int = 10, *args, **kwargs
     ):
+        '''
+        Subsample the valid samples by the rate of `subsample_rate`,
+            if the total num of the valid samples is larger than `subsample_min_num`.
+        '''
         super().__init__(auxiliary_uuid=self.UUID, *args, **kwargs)
 
         self.cross_entropy_loss = nn.CrossEntropyLoss(reduction="none")
@@ -123,23 +174,12 @@ class InverseDynamicsLoss(AuxiliaryLoss):
         actions = actions[:-1]  # (T-1, B)
 
         ## find the final belief state based on masks
-        # we did not compute loss here cuz model.forward is compute-heavy
+        # we did not compute loss here as model.forward is compute-heavy
         masks = masks.squeeze(-1)  # (T, B)
-        final_beliefs = torch.zeros_like(beliefs)  # (T, B, *)
-        for i in range(num_sampler):
-            # right shift: to locate the 1 before 0 and ignore the 1st element
-            end_locs = torch.where(masks[1:, i] == 0)[0]  # maybe [], dtype=torch.Long
 
-            start_locs = torch.cat(
-                [torch.tensor([0]).to(end_locs), end_locs + 1]
-            )  # add the first element
-
-            end_locs = torch.cat(
-                [end_locs, torch.tensor([num_steps - 1]).to(end_locs)]
-            )  # add the last element
-
-            for st, ed in zip(start_locs, end_locs):
-                final_beliefs[st : ed + 1, i] = beliefs[ed, i]
+        final_beliefs, _, _ = _propagate_final_beliefs_to_all_steps(
+            beliefs, masks, num_sampler, num_steps,
+        )
 
         ## compute CE loss
         decoder_in = torch.cat(
@@ -186,7 +226,7 @@ class InverseDynamicsLoss(AuxiliaryLoss):
         else:
             subsample_rate = self.subsample_rate
 
-        loss_masks = masks[1:] * subsampled_masks(masks[1:], subsample_rate)
+        loss_masks = masks[1:] * _bernoulli_subsample_mask_like(masks[1:], subsample_rate)
         num_valid_losses = torch.count_nonzero(loss_masks)
         avg_loss = (loss * loss_masks).sum() / torch.clamp(num_valid_losses, min=1.0)
 
@@ -197,6 +237,10 @@ class InverseDynamicsLoss(AuxiliaryLoss):
 
 
 class TemporalDistanceLoss(AuxiliaryLoss):
+    '''
+    Auxiliary task of Temporal Distance
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+    '''
     UUID = "TempDist"
 
     def __init__(self, num_pairs: int = 8, epsiode_len_min: int = 5, *args, **kwargs):
@@ -221,39 +265,27 @@ class TemporalDistanceLoss(AuxiliaryLoss):
         actions = actions[:-1]  # (T-1, B)
 
         ## find the final belief state based on masks
-        # we did not compute loss here cuz model.forward is compute-heavy
+        # we did not compute loss here as model.forward is compute-heavy
         masks = masks.squeeze(-1)  # (T, B)
-        final_beliefs = torch.zeros_like(beliefs)  # (T, B, *)
 
+        final_beliefs, start_locs_list, end_locs_list = _propagate_final_beliefs_to_all_steps(
+            beliefs, masks, num_sampler, num_steps,
+        )
+        
         ## also find the locs_batch of shape (M, 3)
         # the last dim: [0] is on num_sampler loc, [1] and [2] is start and end locs
         # of one episode
         # in other words: at locs_batch[m, 0] in num_sampler dim, there exists one episode
         # starting from locs_batch[m, 1], ends at locs_batch[m, 2] (included)
         locs_batch = []
-
         for i in range(num_sampler):
-            # right shift: to locate the 1 before 0 and ignore the 1st element
-            end_locs = torch.where(masks[1:, i] == 0)[0]  # maybe [], dtype=torch.Long
-
-            start_locs = torch.cat(
-                [torch.tensor([0]).to(end_locs), end_locs + 1]
-            )  # add the first element
-
-            end_locs = torch.cat(
-                [end_locs, torch.tensor([num_steps - 1]).to(end_locs)]
-            )  # add the last element
-
             locs_batch.append(
                 torch.stack(
-                    [i * torch.ones_like(start_locs), start_locs, end_locs], dim=-1
+                    [i * torch.ones_like(start_locs_list[i]), start_locs_list[i], end_locs_list[i]], dim=-1
                 )
             )  # shape (M[i], 3)
-
-            for st, ed in zip(start_locs, end_locs):
-                final_beliefs[st : ed + 1, i] = beliefs[ed, i]
-
         locs_batch = torch.cat(locs_batch)  # shape (M, 3)
+
         temporal_dist_max = (
             locs_batch[:, 2] - locs_batch[:, 1]
         ).float()  # end - start, (M)
@@ -264,11 +296,11 @@ class TemporalDistanceLoss(AuxiliaryLoss):
             torch.tensor([0]).to(temporal_dist_max),
         )  # (M)
 
-        # sample validpairs: sampled_pairs shape (M, num_pairs, 3)
+        # sample valid pairs: sampled_pairs shape (M, num_pairs, 3)
         # where M is the num of total episodes in the batch
         locs = (
             locs_batch.cpu().numpy()
-        )  # cuz torch.randint only support int, not tensor
+        )  # as torch.randint only support int, not tensor
         sampled_pairs = np.random.randint(
             np.repeat(locs[:, [1]], 2 * self.num_pairs, axis=-1),  # (M, 2*k)
             np.repeat(locs[:, [2]] + 1, 2 * self.num_pairs, axis=-1),  # (M, 2*k)
@@ -317,6 +349,10 @@ class TemporalDistanceLoss(AuxiliaryLoss):
 
 
 class CPCALoss(AuxiliaryLoss):
+    '''
+    Auxiliary task of CPC|A
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+    '''
     UUID = "CPCA"
 
     def __init__(
@@ -454,7 +490,7 @@ class CPCALoss(AuxiliaryLoss):
 
         pred_masks[
             num_steps - 1 :
-        ] = False  # GRU(b_t, a_{t:t+k-1}) is invalid when t >= T, cuz we don't have real z_{t+1}
+        ] = False  # GRU(b_t, a_{t:t+k-1}) is invalid when t >= T, as we don't have real z_{t+1}
         for j in range(1, self.planning_steps + 1):  # for j-step predictions
             pred_masks[
                 : j - 1, j - 1
@@ -478,7 +514,7 @@ class CPCALoss(AuxiliaryLoss):
         )  # (T, N, 1, k) -> (T, k, N, 1)
         # print(valid_masks.int().squeeze(-1)); print(masks) # verify its correctness
 
-        loss_masks = valid_masks * subsampled_masks(
+        loss_masks = valid_masks * _bernoulli_subsample_mask_like(
             valid_masks, self.subsample_rate
         )  # (T, k, N, 1)
         num_valid_losses = torch.count_nonzero(loss_masks)

--- a/allenact/embodiedai/aux_losses/losses.py
+++ b/allenact/embodiedai/aux_losses/losses.py
@@ -143,7 +143,8 @@ def _propagate_final_beliefs_to_all_steps(
 class InverseDynamicsLoss(AuxiliaryLoss):
     """
     Auxiliary task of Inverse Dynamics 
-        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020) https://arxiv.org/abs/2007.04561
+        originally from Curiosity-driven Exploration by Self-supervised Prediction (Pathak, 2017) https://arxiv.org/abs/1705.05363
     """
 
     UUID = "InvDyn"
@@ -245,7 +246,7 @@ class InverseDynamicsLoss(AuxiliaryLoss):
 class TemporalDistanceLoss(AuxiliaryLoss):
     """
     Auxiliary task of Temporal Distance
-        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020) https://arxiv.org/abs/2007.04561
     """
 
     UUID = "TempDist"
@@ -365,7 +366,8 @@ class TemporalDistanceLoss(AuxiliaryLoss):
 class CPCALoss(AuxiliaryLoss):
     """
     Auxiliary task of CPC|A
-        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020) https://arxiv.org/abs/2007.04561
+        originally from Neural Predictive Belief Representations (Guo, 2018) https://arxiv.org/abs/1811.06407
     """
 
     UUID = "CPCA"

--- a/allenact/embodiedai/models/aux_models.py
+++ b/allenact/embodiedai/models/aux_models.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+
+from typing import Tuple, Dict, Optional, Union, List, cast
+
+import torch
+import torch.nn as nn
+
+from allenact.utils.model_utils import FeatureEmbedding
+from allenact.embodiedai.aux_losses.losses import (
+    InverseDynamicsLoss, TemporalDistanceLoss, CPCALoss,
+)
+
+class AuxiliaryModel(nn.Module):
+    def __init__(
+        self, aux_uuid: str, action_dim: int, obs_embed_dim: int, belief_dim: int,
+        action_embed_size: int = 4, cpca_classifier_hidden_dim: int = 32,
+        forward_regressor_hidden_dim: int = 128, disturb_hidden_dim: int = 128,
+    ):
+        super().__init__()
+        self.aux_uuid = aux_uuid
+        self.action_dim = action_dim
+        self.obs_embed_dim = obs_embed_dim
+        self.belief_dim = belief_dim
+
+        if self.aux_uuid == InverseDynamicsLoss.UUID:
+            self.decoder = nn.Linear(
+                2 * self.obs_embed_dim + self.belief_dim, self.action_dim
+            )
+        elif self.aux_uuid == TemporalDistanceLoss.UUID:
+            self.decoder = nn.Linear(
+                2 * self.obs_embed_dim + self.belief_dim, 1
+            )
+        elif CPCALoss.UUID in self.aux_uuid: # the CPCA family with various k
+            ## Auto-regressive model to predict future context
+            self.action_embedder = FeatureEmbedding(self.action_dim+1, action_embed_size) 
+            # NOTE: add extra 1 in embedding dict cuz we will pad zero actions?
+            self.context_model = nn.GRU(action_embed_size, self.belief_dim)
+
+            ## Classifier to estimate mutual information
+            self.classifier =  nn.Sequential(
+                nn.Linear(self.belief_dim + self.obs_embed_dim, cpca_classifier_hidden_dim),
+                nn.ReLU(),
+                nn.Linear(cpca_classifier_hidden_dim, 1)
+            )
+
+        else:
+            raise ValueError("Unknown Auxiliary Loss UUID")
+
+    def forward(self, features: torch.FloatTensor):
+        if self.aux_uuid in [InverseDynamicsLoss.UUID, 
+                            TemporalDistanceLoss.UUID]:
+            return self.decoder(features)
+        else:
+            raise ValueError("Not Support Forward")

--- a/allenact/embodiedai/models/aux_models.py
+++ b/allenact/embodiedai/models/aux_models.py
@@ -7,7 +7,6 @@ Several of the models defined in this file are modified versions of those found 
     https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
 """
 
-from typing import Tuple, Dict, Optional, Union, List, cast
 
 import torch
 import torch.nn as nn

--- a/allenact/embodiedai/models/aux_models.py
+++ b/allenact/embodiedai/models/aux_models.py
@@ -1,7 +1,11 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Original work Copyright (c) Facebook, Inc. and its affiliates.
+# Modified work Copyright (c) Allen Institute for AI
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-# Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+"""
+Several of the models defined in this file are modified versions of those found in 
+    https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+"""
 
 from typing import Tuple, Dict, Optional, Union, List, cast
 
@@ -17,6 +21,9 @@ from allenact.embodiedai.aux_losses.losses import (
 
 
 class AuxiliaryModel(nn.Module):
+    '''
+    The class of defining the models for all kinds of self-supervised auxiliary tasks
+    '''
     def __init__(
         self,
         aux_uuid: str,
@@ -25,8 +32,6 @@ class AuxiliaryModel(nn.Module):
         belief_dim: int,
         action_embed_size: int = 4,
         cpca_classifier_hidden_dim: int = 32,
-        forward_regressor_hidden_dim: int = 128,
-        disturb_hidden_dim: int = 128,
     ):
         super().__init__()
         self.aux_uuid = aux_uuid
@@ -64,4 +69,4 @@ class AuxiliaryModel(nn.Module):
         if self.aux_uuid in [InverseDynamicsLoss.UUID, TemporalDistanceLoss.UUID]:
             return self.decoder(features)
         else:
-            raise ValueError("Not Support Forward")
+            raise NotImplementedError(f"Auxiliary model with UUID {self.aux_uuid} does not support `forward` call.")

--- a/allenact/embodiedai/models/aux_models.py
+++ b/allenact/embodiedai/models/aux_models.py
@@ -21,9 +21,10 @@ from allenact.embodiedai.aux_losses.losses import (
 
 
 class AuxiliaryModel(nn.Module):
-    '''
+    """
     The class of defining the models for all kinds of self-supervised auxiliary tasks
-    '''
+    """
+
     def __init__(
         self,
         aux_uuid: str,
@@ -69,4 +70,6 @@ class AuxiliaryModel(nn.Module):
         if self.aux_uuid in [InverseDynamicsLoss.UUID, TemporalDistanceLoss.UUID]:
             return self.decoder(features)
         else:
-            raise NotImplementedError(f"Auxiliary model with UUID {self.aux_uuid} does not support `forward` call.")
+            raise NotImplementedError(
+                f"Auxiliary model with UUID {self.aux_uuid} does not support `forward` call."
+            )

--- a/allenact/embodiedai/models/aux_models.py
+++ b/allenact/embodiedai/models/aux_models.py
@@ -10,14 +10,23 @@ import torch.nn as nn
 
 from allenact.utils.model_utils import FeatureEmbedding
 from allenact.embodiedai.aux_losses.losses import (
-    InverseDynamicsLoss, TemporalDistanceLoss, CPCALoss,
+    InverseDynamicsLoss,
+    TemporalDistanceLoss,
+    CPCALoss,
 )
+
 
 class AuxiliaryModel(nn.Module):
     def __init__(
-        self, aux_uuid: str, action_dim: int, obs_embed_dim: int, belief_dim: int,
-        action_embed_size: int = 4, cpca_classifier_hidden_dim: int = 32,
-        forward_regressor_hidden_dim: int = 128, disturb_hidden_dim: int = 128,
+        self,
+        aux_uuid: str,
+        action_dim: int,
+        obs_embed_dim: int,
+        belief_dim: int,
+        action_embed_size: int = 4,
+        cpca_classifier_hidden_dim: int = 32,
+        forward_regressor_hidden_dim: int = 128,
+        disturb_hidden_dim: int = 128,
     ):
         super().__init__()
         self.aux_uuid = aux_uuid
@@ -30,28 +39,29 @@ class AuxiliaryModel(nn.Module):
                 2 * self.obs_embed_dim + self.belief_dim, self.action_dim
             )
         elif self.aux_uuid == TemporalDistanceLoss.UUID:
-            self.decoder = nn.Linear(
-                2 * self.obs_embed_dim + self.belief_dim, 1
-            )
-        elif CPCALoss.UUID in self.aux_uuid: # the CPCA family with various k
+            self.decoder = nn.Linear(2 * self.obs_embed_dim + self.belief_dim, 1)
+        elif CPCALoss.UUID in self.aux_uuid:  # the CPCA family with various k
             ## Auto-regressive model to predict future context
-            self.action_embedder = FeatureEmbedding(self.action_dim+1, action_embed_size) 
+            self.action_embedder = FeatureEmbedding(
+                self.action_dim + 1, action_embed_size
+            )
             # NOTE: add extra 1 in embedding dict cuz we will pad zero actions?
             self.context_model = nn.GRU(action_embed_size, self.belief_dim)
 
             ## Classifier to estimate mutual information
-            self.classifier =  nn.Sequential(
-                nn.Linear(self.belief_dim + self.obs_embed_dim, cpca_classifier_hidden_dim),
+            self.classifier = nn.Sequential(
+                nn.Linear(
+                    self.belief_dim + self.obs_embed_dim, cpca_classifier_hidden_dim
+                ),
                 nn.ReLU(),
-                nn.Linear(cpca_classifier_hidden_dim, 1)
+                nn.Linear(cpca_classifier_hidden_dim, 1),
             )
 
         else:
             raise ValueError("Unknown Auxiliary Loss UUID")
 
     def forward(self, features: torch.FloatTensor):
-        if self.aux_uuid in [InverseDynamicsLoss.UUID, 
-                            TemporalDistanceLoss.UUID]:
+        if self.aux_uuid in [InverseDynamicsLoss.UUID, TemporalDistanceLoss.UUID]:
             return self.decoder(features)
         else:
             raise ValueError("Not Support Forward")

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -1,0 +1,109 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+
+from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
+from allenact.utils.system import get_logger
+
+import math
+import torch
+import torch.nn as nn
+
+class Fusion(nn.Module):
+    def __init__(self, hidden_size, obs_embed_size, num_tasks):
+        super().__init__()
+        self.hidden_size = hidden_size # H
+        self.obs_embed_size = obs_embed_size # Z
+        self.num_tasks = num_tasks # k
+
+    def forward(self, 
+        total_beliefs: torch.FloatTensor, # (T, N, H, K)
+        obs_embeds: torch.FloatTensor, # (T, N, Z)
+    )-> Tuple[torch.FloatTensor, torch.FloatTensor]: # (T, N, H), (T, N, K)
+
+        num_steps, num_samplers, _, _ = total_beliefs.shape
+        total_beliefs = total_beliefs.view(num_steps*num_samplers, self.hidden_size, self.num_tasks)
+        obs_embeds = obs_embeds.view(num_steps*num_samplers, -1)
+
+        weights = self.get_belief_weights(
+                        total_beliefs=total_beliefs, # (T*N, H, K)
+                        obs_embeds=obs_embeds, # (T*N, Z)
+                    ).unsqueeze(-1) # (T*N, K, 1)
+        
+        beliefs = torch.bmm(total_beliefs, weights) # (T*N, H, 1)
+
+        beliefs = beliefs.squeeze(-1).view(num_steps, num_samplers, self.hidden_size)
+        weights = weights.squeeze(-1).view(num_steps, num_samplers, self.num_tasks)
+
+        return beliefs, weights
+    
+    def get_belief_weights(self, 
+        total_beliefs: torch.FloatTensor, # (T*N, H, K)
+        obs_embeds: torch.FloatTensor, # (T*N, Z)
+    )-> torch.FloatTensor: # (T*N, K)
+        raise NotImplementedError()
+
+
+class AverageFusion(Fusion):
+    UUID = "avg"
+
+    def get_belief_weights(self, 
+        total_beliefs: torch.FloatTensor, # (T*N, H, K)
+        obs_embeds: torch.FloatTensor, # (T*N, Z)
+    )-> torch.FloatTensor: # (T*N, K)
+
+        batch_size = total_beliefs.shape[0]
+        weights = torch.ones(batch_size, self.num_tasks).to(total_beliefs)
+        weights /= self.num_tasks
+        return weights
+
+class SoftmaxFusion(Fusion):
+    UUID = "smax"
+    '''
+    Situational Fusion of Visual Representation for Visual Navigation
+    https://arxiv.org/abs/1908.09073
+    '''
+
+    def __init__(self, hidden_size, obs_embed_size, num_tasks):
+        super().__init__(hidden_size, obs_embed_size, num_tasks)
+        # mapping from rnn input to task
+        # ignore beliefs
+        self.linear = nn.Linear(obs_embed_size, num_tasks) 
+
+    def get_belief_weights(self, 
+        total_beliefs: torch.FloatTensor, # (T*N, H, K)
+        obs_embeds: torch.FloatTensor, # (T*N, Z)
+    )-> torch.FloatTensor: # (T*N, K)
+
+        scores = self.linear(obs_embeds) # (T*N, K)
+        weights = torch.softmax(scores, dim=-1)
+        return weights
+
+class AttentiveFusion(Fusion):
+    UUID = "attn"
+    '''
+    Attention is All You Need
+    https://arxiv.org/abs/1706.03762
+    i.e. scaled dot-product attention
+    '''
+
+    def __init__(self, hidden_size, obs_embed_size, num_tasks):
+        super().__init__(hidden_size, obs_embed_size, num_tasks)
+        self.linear = nn.Linear(obs_embed_size, hidden_size) 
+
+    def get_belief_weights(self, 
+        total_beliefs: torch.FloatTensor, # (T*N, H, K)
+        obs_embeds: torch.FloatTensor, # (T*N, Z)
+    )-> torch.FloatTensor: # (T*N, K)
+
+        queries = self.linear(obs_embeds).unsqueeze(1) # (T*N, 1, H)
+        scores = torch.bmm(queries, total_beliefs).squeeze(1) # (T*N, K)
+        weights = torch.softmax(scores / math.sqrt(self.hidden_size), dim=-1) # (T*N, K)
+        return weights
+
+FusionModels = {
+    AverageFusion.UUID: AverageFusion,
+    SoftmaxFusion.UUID: SoftmaxFusion,
+    AttentiveFusion.UUID: AttentiveFusion,
+}

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -10,97 +10,112 @@ import math
 import torch
 import torch.nn as nn
 
+
 class Fusion(nn.Module):
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__()
-        self.hidden_size = hidden_size # H
-        self.obs_embed_size = obs_embed_size # Z
-        self.num_tasks = num_tasks # k
+        self.hidden_size = hidden_size  # H
+        self.obs_embed_size = obs_embed_size  # Z
+        self.num_tasks = num_tasks  # k
 
-    def forward(self, 
-        total_beliefs: torch.FloatTensor, # (T, N, H, K)
-        obs_embeds: torch.FloatTensor, # (T, N, Z)
-    )-> Tuple[torch.FloatTensor, torch.FloatTensor]: # (T, N, H), (T, N, K)
+    def forward(
+        self,
+        total_beliefs: torch.FloatTensor,  # (T, N, H, K)
+        obs_embeds: torch.FloatTensor,  # (T, N, Z)
+    ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:  # (T, N, H), (T, N, K)
 
         num_steps, num_samplers, _, _ = total_beliefs.shape
-        total_beliefs = total_beliefs.view(num_steps*num_samplers, self.hidden_size, self.num_tasks)
-        obs_embeds = obs_embeds.view(num_steps*num_samplers, -1)
+        total_beliefs = total_beliefs.view(
+            num_steps * num_samplers, self.hidden_size, self.num_tasks
+        )
+        obs_embeds = obs_embeds.view(num_steps * num_samplers, -1)
 
         weights = self.get_belief_weights(
-                        total_beliefs=total_beliefs, # (T*N, H, K)
-                        obs_embeds=obs_embeds, # (T*N, Z)
-                    ).unsqueeze(-1) # (T*N, K, 1)
-        
-        beliefs = torch.bmm(total_beliefs, weights) # (T*N, H, 1)
+            total_beliefs=total_beliefs,  # (T*N, H, K)
+            obs_embeds=obs_embeds,  # (T*N, Z)
+        ).unsqueeze(
+            -1
+        )  # (T*N, K, 1)
+
+        beliefs = torch.bmm(total_beliefs, weights)  # (T*N, H, 1)
 
         beliefs = beliefs.squeeze(-1).view(num_steps, num_samplers, self.hidden_size)
         weights = weights.squeeze(-1).view(num_steps, num_samplers, self.num_tasks)
 
         return beliefs, weights
-    
-    def get_belief_weights(self, 
-        total_beliefs: torch.FloatTensor, # (T*N, H, K)
-        obs_embeds: torch.FloatTensor, # (T*N, Z)
-    )-> torch.FloatTensor: # (T*N, K)
+
+    def get_belief_weights(
+        self,
+        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        obs_embeds: torch.FloatTensor,  # (T*N, Z)
+    ) -> torch.FloatTensor:  # (T*N, K)
         raise NotImplementedError()
 
 
 class AverageFusion(Fusion):
     UUID = "avg"
 
-    def get_belief_weights(self, 
-        total_beliefs: torch.FloatTensor, # (T*N, H, K)
-        obs_embeds: torch.FloatTensor, # (T*N, Z)
-    )-> torch.FloatTensor: # (T*N, K)
+    def get_belief_weights(
+        self,
+        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        obs_embeds: torch.FloatTensor,  # (T*N, Z)
+    ) -> torch.FloatTensor:  # (T*N, K)
 
         batch_size = total_beliefs.shape[0]
         weights = torch.ones(batch_size, self.num_tasks).to(total_beliefs)
         weights /= self.num_tasks
         return weights
 
+
 class SoftmaxFusion(Fusion):
     UUID = "smax"
-    '''
+    """
     Situational Fusion of Visual Representation for Visual Navigation
     https://arxiv.org/abs/1908.09073
-    '''
+    """
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__(hidden_size, obs_embed_size, num_tasks)
         # mapping from rnn input to task
         # ignore beliefs
-        self.linear = nn.Linear(obs_embed_size, num_tasks) 
+        self.linear = nn.Linear(obs_embed_size, num_tasks)
 
-    def get_belief_weights(self, 
-        total_beliefs: torch.FloatTensor, # (T*N, H, K)
-        obs_embeds: torch.FloatTensor, # (T*N, Z)
-    )-> torch.FloatTensor: # (T*N, K)
+    def get_belief_weights(
+        self,
+        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        obs_embeds: torch.FloatTensor,  # (T*N, Z)
+    ) -> torch.FloatTensor:  # (T*N, K)
 
-        scores = self.linear(obs_embeds) # (T*N, K)
+        scores = self.linear(obs_embeds)  # (T*N, K)
         weights = torch.softmax(scores, dim=-1)
         return weights
 
+
 class AttentiveFusion(Fusion):
     UUID = "attn"
-    '''
+    """
     Attention is All You Need
     https://arxiv.org/abs/1706.03762
     i.e. scaled dot-product attention
-    '''
+    """
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__(hidden_size, obs_embed_size, num_tasks)
-        self.linear = nn.Linear(obs_embed_size, hidden_size) 
+        self.linear = nn.Linear(obs_embed_size, hidden_size)
 
-    def get_belief_weights(self, 
-        total_beliefs: torch.FloatTensor, # (T*N, H, K)
-        obs_embeds: torch.FloatTensor, # (T*N, Z)
-    )-> torch.FloatTensor: # (T*N, K)
+    def get_belief_weights(
+        self,
+        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        obs_embeds: torch.FloatTensor,  # (T*N, Z)
+    ) -> torch.FloatTensor:  # (T*N, K)
 
-        queries = self.linear(obs_embeds).unsqueeze(1) # (T*N, 1, H)
-        scores = torch.bmm(queries, total_beliefs).squeeze(1) # (T*N, K)
-        weights = torch.softmax(scores / math.sqrt(self.hidden_size), dim=-1) # (T*N, K)
+        queries = self.linear(obs_embeds).unsqueeze(1)  # (T*N, 1, H)
+        scores = torch.bmm(queries, total_beliefs).squeeze(1)  # (T*N, K)
+        weights = torch.softmax(
+            scores / math.sqrt(self.hidden_size), dim=-1
+        )  # (T*N, K)
         return weights
+
 
 FusionModels = {
     AverageFusion.UUID: AverageFusion,

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -13,12 +13,13 @@ import torch.nn as nn
 
 
 class Fusion(nn.Module):
-    '''
+    """
     Base class of belief fusion model 
         from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
     Child class should implement `get_belief_weights` function to generate weights 
         to fuse the beliefs from all the auxiliary task into one.
-    ''' 
+    """
+
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__()
         self.hidden_size = hidden_size  # H
@@ -38,8 +39,7 @@ class Fusion(nn.Module):
         obs_embeds = obs_embeds.view(num_steps * num_samplers, -1)
 
         weights = self.get_belief_weights(
-            all_beliefs=all_beliefs,  # (T*N, H, K)
-            obs_embeds=obs_embeds,  # (T*N, Z)
+            all_beliefs=all_beliefs, obs_embeds=obs_embeds,  # (T*N, H, K)  # (T*N, Z)
         ).unsqueeze(
             -1
         )  # (T*N, K, 1)
@@ -79,6 +79,7 @@ class SoftmaxFusion(Fusion):
     Situational Fusion of Visual Representation for Visual Navigation
     https://arxiv.org/abs/1908.09073
     """
+
     UUID = "smax"
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
@@ -104,6 +105,7 @@ class AttentiveFusion(Fusion):
     https://arxiv.org/abs/1706.03762
     i.e. scaled dot-product attention
     """
+
     UUID = "attn"
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -4,8 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 # Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
 
-from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
-from allenact.utils.system import get_logger
+from typing import Tuple
 
 import math
 import torch

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -122,10 +122,3 @@ class AttentiveFusion(Fusion):
             scores / math.sqrt(self.hidden_size), dim=-1
         )  # (T*N, K)
         return weights
-
-
-FusionModels = {
-    AverageFusion.UUID: AverageFusion,
-    SoftmaxFusion.UUID: SoftmaxFusion,
-    AttentiveFusion.UUID: AttentiveFusion,
-}

--- a/allenact/embodiedai/models/fusion_models.py
+++ b/allenact/embodiedai/models/fusion_models.py
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Original work Copyright (c) Facebook, Inc. and its affiliates.
+# Modified work Copyright (c) Allen Institute for AI
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 # Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
@@ -12,6 +13,12 @@ import torch.nn as nn
 
 
 class Fusion(nn.Module):
+    '''
+    Base class of belief fusion model 
+        from Auxiliary Tasks Speed Up Learning PointGoal Navigation (Ye, 2020)
+    Child class should implement `get_belief_weights` function to generate weights 
+        to fuse the beliefs from all the auxiliary task into one.
+    ''' 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__()
         self.hidden_size = hidden_size  # H
@@ -20,24 +27,24 @@ class Fusion(nn.Module):
 
     def forward(
         self,
-        total_beliefs: torch.FloatTensor,  # (T, N, H, K)
+        all_beliefs: torch.FloatTensor,  # (T, N, H, K)
         obs_embeds: torch.FloatTensor,  # (T, N, Z)
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:  # (T, N, H), (T, N, K)
 
-        num_steps, num_samplers, _, _ = total_beliefs.shape
-        total_beliefs = total_beliefs.view(
+        num_steps, num_samplers, _, _ = all_beliefs.shape
+        all_beliefs = all_beliefs.view(
             num_steps * num_samplers, self.hidden_size, self.num_tasks
         )
         obs_embeds = obs_embeds.view(num_steps * num_samplers, -1)
 
         weights = self.get_belief_weights(
-            total_beliefs=total_beliefs,  # (T*N, H, K)
+            all_beliefs=all_beliefs,  # (T*N, H, K)
             obs_embeds=obs_embeds,  # (T*N, Z)
         ).unsqueeze(
             -1
         )  # (T*N, K, 1)
 
-        beliefs = torch.bmm(total_beliefs, weights)  # (T*N, H, 1)
+        beliefs = torch.bmm(all_beliefs, weights)  # (T*N, H, 1)
 
         beliefs = beliefs.squeeze(-1).view(num_steps, num_samplers, self.hidden_size)
         weights = weights.squeeze(-1).view(num_steps, num_samplers, self.num_tasks)
@@ -46,7 +53,7 @@ class Fusion(nn.Module):
 
     def get_belief_weights(
         self,
-        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        all_beliefs: torch.FloatTensor,  # (T*N, H, K)
         obs_embeds: torch.FloatTensor,  # (T*N, Z)
     ) -> torch.FloatTensor:  # (T*N, K)
         raise NotImplementedError()
@@ -57,22 +64,22 @@ class AverageFusion(Fusion):
 
     def get_belief_weights(
         self,
-        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        all_beliefs: torch.FloatTensor,  # (T*N, H, K)
         obs_embeds: torch.FloatTensor,  # (T*N, Z)
     ) -> torch.FloatTensor:  # (T*N, K)
 
-        batch_size = total_beliefs.shape[0]
-        weights = torch.ones(batch_size, self.num_tasks).to(total_beliefs)
+        batch_size = all_beliefs.shape[0]
+        weights = torch.ones(batch_size, self.num_tasks).to(all_beliefs)
         weights /= self.num_tasks
         return weights
 
 
 class SoftmaxFusion(Fusion):
-    UUID = "smax"
     """
     Situational Fusion of Visual Representation for Visual Navigation
     https://arxiv.org/abs/1908.09073
     """
+    UUID = "smax"
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__(hidden_size, obs_embed_size, num_tasks)
@@ -82,7 +89,7 @@ class SoftmaxFusion(Fusion):
 
     def get_belief_weights(
         self,
-        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        all_beliefs: torch.FloatTensor,  # (T*N, H, K)
         obs_embeds: torch.FloatTensor,  # (T*N, Z)
     ) -> torch.FloatTensor:  # (T*N, K)
 
@@ -92,12 +99,12 @@ class SoftmaxFusion(Fusion):
 
 
 class AttentiveFusion(Fusion):
-    UUID = "attn"
     """
     Attention is All You Need
     https://arxiv.org/abs/1706.03762
     i.e. scaled dot-product attention
     """
+    UUID = "attn"
 
     def __init__(self, hidden_size, obs_embed_size, num_tasks):
         super().__init__(hidden_size, obs_embed_size, num_tasks)
@@ -105,12 +112,12 @@ class AttentiveFusion(Fusion):
 
     def get_belief_weights(
         self,
-        total_beliefs: torch.FloatTensor,  # (T*N, H, K)
+        all_beliefs: torch.FloatTensor,  # (T*N, H, K)
         obs_embeds: torch.FloatTensor,  # (T*N, Z)
     ) -> torch.FloatTensor:  # (T*N, K)
 
         queries = self.linear(obs_embeds).unsqueeze(1)  # (T*N, 1, H)
-        scores = torch.bmm(queries, total_beliefs).squeeze(1)  # (T*N, K)
+        scores = torch.bmm(queries, all_beliefs).squeeze(1)  # (T*N, K)
         weights = torch.softmax(
             scores / math.sqrt(self.hidden_size), dim=-1
         )  # (T*N, K)

--- a/allenact/embodiedai/models/resnet.py
+++ b/allenact/embodiedai/models/resnet.py
@@ -266,7 +266,9 @@ def gnresneXt50(in_channels, base_planes, ngroups):
 
 
 def se_gnresnet50(in_channels, base_planes, ngroups):
-    model = GroupNormResNet(in_channels, base_planes, ngroups, SEBottleneck, [3, 4, 6, 3])
+    model = GroupNormResNet(
+        in_channels, base_planes, ngroups, SEBottleneck, [3, 4, 6, 3]
+    )
 
     return model
 

--- a/allenact/embodiedai/models/resnet.py
+++ b/allenact/embodiedai/models/resnet.py
@@ -4,17 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 # Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
 
-from typing import (
-    Sequence,
-    Dict,
-    Union,
-    cast,
-    List,
-    Callable,
-    Optional,
-    Tuple,
-    Any,
-)
+from typing import Optional
 
 import numpy as np
 import torch

--- a/allenact/embodiedai/models/resnet.py
+++ b/allenact/embodiedai/models/resnet.py
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Original work Copyright (c) Facebook, Inc. and its affiliates.
+# Modified work Copyright (c) Allen Institute for AI
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 # Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
@@ -166,9 +167,9 @@ class ResNeXtBottleneck(Bottleneck):
     resneXt = True
 
 
-class ResNet(nn.Module):
+class GroupNormResNet(nn.Module):
     def __init__(self, in_channels, base_planes, ngroups, block, layers, cardinality=1):
-        super(ResNet, self).__init__()
+        super(GroupNormResNet, self).__init__()
         self.conv1 = nn.Sequential(
             nn.Conv2d(
                 in_channels,
@@ -239,20 +240,20 @@ class ResNet(nn.Module):
         return x
 
 
-def resnet18(in_channels, base_planes, ngroups):
-    model = ResNet(in_channels, base_planes, ngroups, BasicBlock, [2, 2, 2, 2])
+def gnresnet18(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(in_channels, base_planes, ngroups, BasicBlock, [2, 2, 2, 2])
 
     return model
 
 
-def resnet50(in_channels, base_planes, ngroups):
-    model = ResNet(in_channels, base_planes, ngroups, Bottleneck, [3, 4, 6, 3])
+def gnresnet50(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(in_channels, base_planes, ngroups, Bottleneck, [3, 4, 6, 3])
 
     return model
 
 
-def resneXt50(in_channels, base_planes, ngroups):
-    model = ResNet(
+def gnresneXt50(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(
         in_channels,
         base_planes,
         ngroups,
@@ -264,14 +265,14 @@ def resneXt50(in_channels, base_planes, ngroups):
     return model
 
 
-def se_resnet50(in_channels, base_planes, ngroups):
-    model = ResNet(in_channels, base_planes, ngroups, SEBottleneck, [3, 4, 6, 3])
+def se_gnresnet50(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(in_channels, base_planes, ngroups, SEBottleneck, [3, 4, 6, 3])
 
     return model
 
 
-def se_resneXt50(in_channels, base_planes, ngroups):
-    model = ResNet(
+def se_gnresneXt50(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(
         in_channels,
         base_planes,
         ngroups,
@@ -283,8 +284,8 @@ def se_resneXt50(in_channels, base_planes, ngroups):
     return model
 
 
-def se_resneXt101(in_channels, base_planes, ngroups):
-    model = ResNet(
+def se_gnresneXt101(in_channels, base_planes, ngroups):
+    model = GroupNormResNet(
         in_channels,
         base_planes,
         ngroups,
@@ -296,7 +297,7 @@ def se_resneXt101(in_channels, base_planes, ngroups):
     return model
 
 
-class ResNetEncoder(nn.Module):
+class GroupNormResNetEncoder(nn.Module):
     def __init__(
         self,
         observation_space: SpaceDict,

--- a/allenact/embodiedai/models/resnet.py
+++ b/allenact/embodiedai/models/resnet.py
@@ -1,0 +1,469 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# Adapted from https://github.com/joel99/habitat-pointnav-aux/blob/master/habitat_baselines/
+
+from typing import (
+    Sequence,
+    Dict,
+    Union,
+    cast,
+    List,
+    Callable,
+    Optional,
+    Tuple,
+    Any,
+)
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from gym.spaces.dict import Dict as SpaceDict
+from allenact.utils.model_utils import Flatten
+from allenact.utils.system import get_logger
+
+def conv3x3(in_planes, out_planes, stride=1, groups=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=1,
+        bias=False,
+        groups=groups,
+    )
+
+
+def conv1x1(in_planes, out_planes, stride=1):
+    """1x1 convolution"""
+    return nn.Conv2d(
+        in_planes, out_planes, kernel_size=1, stride=stride, bias=False
+    )
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+    resneXt = False
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        ngroups,
+        stride=1,
+        downsample=None,
+        cardinality=1,
+    ):
+        super(BasicBlock, self).__init__()
+        self.convs = nn.Sequential(
+            conv3x3(inplanes, planes, stride, groups=cardinality),
+            nn.GroupNorm(ngroups, planes),
+            nn.ReLU(True),
+            conv3x3(planes, planes, groups=cardinality),
+            nn.GroupNorm(ngroups, planes),
+        )
+        self.downsample = downsample
+        self.relu = nn.ReLU(True)
+
+    def forward(self, x):
+        residual = x
+
+        out = self.convs(x)
+
+        if self.downsample is not None:
+            residual = self.downsample(x)
+
+        return self.relu(out + residual)
+
+
+def _build_bottleneck_branch(
+    inplanes, planes, ngroups, stride, expansion, groups=1
+):
+    return nn.Sequential(
+        conv1x1(inplanes, planes),
+        nn.GroupNorm(ngroups, planes),
+        nn.ReLU(True),
+        conv3x3(planes, planes, stride, groups=groups),
+        nn.GroupNorm(ngroups, planes),
+        nn.ReLU(True),
+        conv1x1(planes, planes * expansion),
+        nn.GroupNorm(ngroups, planes * expansion),
+    )
+
+
+class SE(nn.Module):
+    def __init__(self, planes, r=16):
+        super().__init__()
+        self.squeeze = nn.AdaptiveAvgPool2d(1)
+        self.excite = nn.Sequential(
+            nn.Linear(planes, int(planes / r)),
+            nn.ReLU(True),
+            nn.Linear(int(planes / r), planes),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        b, c, _, _ = x.size()
+        x = self.squeeze(x)
+        x = x.view(b, c)
+        x = self.excite(x)
+
+        return x.view(b, c, 1, 1)
+
+
+def _build_se_branch(planes, r=16):
+    return SE(planes, r)
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+    resneXt = False
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        ngroups,
+        stride=1,
+        downsample=None,
+        cardinality=1,
+    ):
+        super().__init__()
+        self.convs = _build_bottleneck_branch(
+            inplanes,
+            planes,
+            ngroups,
+            stride,
+            self.expansion,
+            groups=cardinality,
+        )
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+
+    def _impl(self, x):
+        identity = x
+
+        out = self.convs(x)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        return self.relu(out + identity)
+
+    def forward(self, x):
+        return self._impl(x)
+
+
+class SEBottleneck(Bottleneck):
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        ngroups,
+        stride=1,
+        downsample=None,
+        cardinality=1,
+    ):
+        super().__init__(
+            inplanes, planes, ngroups, stride, downsample, cardinality
+        )
+
+        self.se = _build_se_branch(planes * self.expansion)
+
+    def _impl(self, x):
+        identity = x
+
+        out = self.convs(x)
+        out = self.se(out) * out
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        return self.relu(out + identity)
+
+
+class SEResNeXtBottleneck(SEBottleneck):
+    expansion = 2
+    resneXt = True
+
+
+class ResNeXtBottleneck(Bottleneck):
+    expansion = 2
+    resneXt = True
+
+class ResNet(nn.Module):
+    def __init__(
+        self, in_channels, base_planes, ngroups, block, layers, cardinality=1
+    ):
+        super(ResNet, self).__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                base_planes,
+                kernel_size=7,
+                stride=2,
+                padding=3,
+                bias=False,
+            ),
+            nn.GroupNorm(ngroups, base_planes),
+            nn.ReLU(True),
+        )
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.cardinality = cardinality
+
+        self.inplanes = base_planes
+        if block.resneXt:
+            base_planes *= 2
+
+        self.layer1 = self._make_layer(block, ngroups, base_planes, layers[0])
+        self.layer2 = self._make_layer(
+            block, ngroups, base_planes * 2, layers[1], stride=2
+        )
+        self.layer3 = self._make_layer(
+            block, ngroups, base_planes * 2 * 2, layers[2], stride=2
+        )
+        self.layer4 = self._make_layer(
+            block, ngroups, base_planes * 2 * 2 * 2, layers[3], stride=2
+        )
+
+        self.final_channels = self.inplanes
+        self.final_spatial_compress = 1.0 / (2 ** 5)
+
+    def _make_layer(self, block, ngroups, planes, blocks, stride=1):
+        downsample = None
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                nn.GroupNorm(ngroups, planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                ngroups,
+                stride,
+                downsample,
+                cardinality=self.cardinality,
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for i in range(1, blocks):
+            layers.append(block(self.inplanes, planes, ngroups))
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        return x
+
+
+def resnet18(in_channels, base_planes, ngroups):
+    model = ResNet(in_channels, base_planes, ngroups, BasicBlock, [2, 2, 2, 2])
+
+    return model
+
+
+def resnet50(in_channels, base_planes, ngroups):
+    model = ResNet(in_channels, base_planes, ngroups, Bottleneck, [3, 4, 6, 3])
+
+    return model
+
+
+def resneXt50(in_channels, base_planes, ngroups):
+    model = ResNet(
+        in_channels,
+        base_planes,
+        ngroups,
+        ResNeXtBottleneck,
+        [3, 4, 6, 3],
+        cardinality=int(base_planes / 2),
+    )
+
+    return model
+
+
+def se_resnet50(in_channels, base_planes, ngroups):
+    model = ResNet(
+        in_channels, base_planes, ngroups, SEBottleneck, [3, 4, 6, 3]
+    )
+
+    return model
+
+
+def se_resneXt50(in_channels, base_planes, ngroups):
+    model = ResNet(
+        in_channels,
+        base_planes,
+        ngroups,
+        SEResNeXtBottleneck,
+        [3, 4, 6, 3],
+        cardinality=int(base_planes / 2),
+    )
+
+    return model
+
+
+def se_resneXt101(in_channels, base_planes, ngroups):
+    model = ResNet(
+        in_channels,
+        base_planes,
+        ngroups,
+        SEResNeXtBottleneck,
+        [3, 4, 23, 3],
+        cardinality=int(base_planes / 2),
+    )
+
+    return model
+
+
+class ResNetEncoder(nn.Module):
+    def __init__(
+        self,
+        observation_space: SpaceDict,
+        rgb_uuid: Optional[str],
+        depth_uuid: Optional[str],
+        output_size: int,
+        baseplanes=32,
+        ngroups=32,
+        spatial_size=128,
+        make_backbone=None,
+    ):
+        super().__init__()
+
+        self._inputs = []
+
+        self.rgb_uuid = rgb_uuid
+        if self.rgb_uuid is not None:
+            assert self.rgb_uuid in observation_space.spaces
+            self._n_input_rgb = observation_space.spaces[self.rgb_uuid].shape[2]
+            assert self._n_input_rgb >= 0
+            self._inputs.append(self.rgb_uuid)
+        else:
+            self._n_input_rgb = 0
+
+        self.depth_uuid = depth_uuid
+        if self.depth_uuid is not None:
+            assert self.depth_uuid in observation_space.spaces
+            self._n_input_depth = observation_space.spaces[self.depth_uuid].shape[2]
+            assert self._n_input_depth >= 0
+            self._inputs.append(self.depth_uuid)
+        else:
+            self._n_input_depth = 0
+
+        if not self.is_blind:
+            spatial_size = observation_space.spaces[self._inputs[0]].shape[0] // 2 # H (=W) / 2
+            # RGBD into one model
+            input_channels = self._n_input_rgb + self._n_input_depth # C
+            
+            self.backbone = make_backbone(input_channels, baseplanes, ngroups)
+
+            final_spatial = int(np.ceil(
+                spatial_size * self.backbone.final_spatial_compress
+            ))  # fix bug in habitat that uses int()
+            after_compression_flat_size = 2048
+            num_compression_channels = int(
+                round(after_compression_flat_size / (final_spatial ** 2))
+            )
+            self.compression = nn.Sequential(
+                nn.Conv2d(
+                    self.backbone.final_channels,
+                    num_compression_channels,
+                    kernel_size=3,
+                    padding=1,
+                    bias=False,
+                ),
+                nn.GroupNorm(1, num_compression_channels),
+                nn.ReLU(True),
+            )
+
+            self.output_shape = (
+                num_compression_channels,
+                final_spatial,
+                final_spatial,
+            )
+
+            self.head = nn.Sequential(
+                Flatten(),
+                nn.Linear(
+                    np.prod(self.output_shape), output_size
+                ),
+                nn.ReLU(True),
+            )
+
+            self.layer_init()
+
+    @property
+    def is_blind(self):
+        return self._n_input_rgb + self._n_input_depth == 0
+
+    def layer_init(self):
+        for layer in self.modules():
+            if isinstance(layer, (nn.Conv2d, nn.Linear)):
+                nn.init.kaiming_normal_(
+                    layer.weight, nn.init.calculate_gain("relu")
+                )
+                if layer.bias is not None:
+                    nn.init.constant_(layer.bias, val=0)
+        get_logger().info("initialize resnet encoder")
+
+    def forward(self, observations):
+        if self.is_blind:
+            return None
+
+        # TODO: the reshape follows compute_cnn_output() 
+        # but it's hard to make the forward as a nn.Module as cnn param
+        cnn_input = []
+        for mode in self._inputs:
+            mode_obs = observations[mode]
+            assert len(mode_obs.shape) in [
+                5,
+                6,
+            ], "CNN input must have shape [STEP, SAMPLER, (AGENT,) dim1, dim2, dim3]"
+            nagents: Optional[int] = None
+            if len(mode_obs.shape) == 6:
+                nsteps, nsamplers, nagents = mode_obs.shape[:3]
+            else:
+                nsteps, nsamplers = mode_obs.shape[:2]
+            # Make FLAT_BATCH = nsteps * nsamplers (* nagents)
+            mode_obs = mode_obs.view((-1,) + mode_obs.shape[2 + int(nagents is not None) :])
+            # permute tensor to dimension [BATCH x CHANNEL x HEIGHT X WIDTH]
+            mode_obs = mode_obs.permute(0, 3, 1, 2)
+            cnn_input.append(mode_obs)
+
+        x = torch.cat(cnn_input, dim=1)
+        x = F.avg_pool2d(x, 2) # 2x downsampling
+
+        x = self.backbone(x) # (256, 4, 4)
+        x = self.compression(x) # (128, 4, 4)
+        x = self.head(x) # (2048) -> (hidden_size)
+
+        if nagents is not None:
+            x = x.reshape(
+                (
+                    nsteps,
+                    nsamplers,
+                    nagents,
+                )
+                + x.shape[1:]
+            )
+        else:
+            x = x.reshape(
+                (
+                    nsteps,
+                    nsamplers,
+                )
+                + x.shape[1:]
+            )
+
+        return x

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -111,7 +111,7 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
         )
 
     def load_state_dict(self, state_dict):
-        new_state_dict = state_dict.copy()
+        new_state_dict = OrderedDict()
         for key in state_dict.keys():
             if "state_encoder." in key:  # old key name
                 new_key = key.replace("state_encoder.", "state_encoders.single_belief.")
@@ -119,9 +119,7 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
                 new_key = key
             new_state_dict[new_key] = state_dict[key]
 
-        return super().load_state_dict(
-            new_state_dict, strict=False
-        )  # compatible in keys
+        return super().load_state_dict(new_state_dict)  # compatible in keys
 
     def create_actorcritic_head(self):
         self.actor = LinearActorHead(self._hidden_size, self.action_space.n)

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
+from typing import Tuple, Dict, Optional
 from allenact.utils.system import get_logger
 from collections import OrderedDict
 

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -1,0 +1,202 @@
+from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
+from allenact.utils.system import get_logger
+from collections import OrderedDict
+
+import gym
+import torch
+import torch.nn as nn
+from gym.spaces.dict import Dict as SpaceDict
+
+from allenact.algorithms.onpolicy_sync.policy import (
+    ActorCriticModel,
+    LinearCriticHead,
+    LinearActorHead,
+    ObservationType,
+    DistributionType,
+)
+from allenact.base_abstractions.distributions import CategoricalDistr
+from allenact.base_abstractions.misc import ActorCriticOutput, Memory
+from allenact.utils.model_utils import FeatureEmbedding
+from allenact.embodiedai.models.basic_models import RNNStateEncoder
+from allenact.embodiedai.models.aux_models import AuxiliaryModel
+from allenact.embodiedai.models.fusion_models import FusionModels
+from allenact.embodiedai.aux_losses.losses import TaskWeightsLoss
+
+class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
+    def __init__(
+        self,
+        action_space: gym.spaces.Discrete,
+        observation_space: SpaceDict,
+        hidden_size=512,
+        multiple_beliefs=False,
+        beliefs_fusion: Optional[str]=None,
+        auxiliary_uuids: Optional[List[str]] = None,
+    ):
+        super().__init__(action_space=action_space, observation_space=observation_space)
+        self._hidden_size = hidden_size
+        self.multiple_beliefs = multiple_beliefs
+        self.beliefs_fusion = beliefs_fusion
+        self.auxiliary_uuids = auxiliary_uuids
+        if isinstance(self.auxiliary_uuids, list) and len(self.auxiliary_uuids) == 0:
+            self.auxiliary_uuids = None
+
+    def create_state_encoders(
+        self, 
+        obs_embed_size: int, 
+        prev_action_embed_size: int,
+        num_rnn_layers: int, 
+        rnn_type: str,
+        add_prev_actions: bool,
+        trainable_masked_hidden_state=False,
+    ):
+        rnn_input_size = obs_embed_size
+        self.prev_action_embedder = FeatureEmbedding(
+                                            input_size = self.action_space.n, 
+                                            output_size = prev_action_embed_size if add_prev_actions else 0,
+                                    )
+        if add_prev_actions:
+            rnn_input_size += prev_action_embed_size
+
+        state_encoders = OrderedDict() # perserve insertion order in py3.6
+        if self.multiple_beliefs: # multiple belief model
+            for aux_uuid in self.auxiliary_uuids:
+                state_encoders[aux_uuid] = RNNStateEncoder(
+                    rnn_input_size,
+                    self._hidden_size,
+                    num_layers=num_rnn_layers,
+                    rnn_type=rnn_type,
+                    trainable_masked_hidden_state=trainable_masked_hidden_state,
+                )
+            # create fusion model
+            self.fusion_model = FusionModels[self.beliefs_fusion](
+                hidden_size=self._hidden_size,
+                obs_embed_size=obs_embed_size,
+                num_tasks=len(self.auxiliary_uuids),
+            )
+
+        else: # single belief model 
+            state_encoders['single_belief'] = RNNStateEncoder(
+                rnn_input_size,
+                self._hidden_size,
+                num_layers=num_rnn_layers,
+                rnn_type=rnn_type,
+                trainable_masked_hidden_state=trainable_masked_hidden_state,
+            )
+        
+        self.state_encoders = nn.ModuleDict(state_encoders)
+
+        self.belief_names = list(self.state_encoders.keys())
+
+        get_logger().info("there are {} belief models: {}".format(
+                len(self.belief_names), self.belief_names
+        ))
+        
+
+    def create_actorcritic_head(self):
+        self.actor = LinearActorHead(self._hidden_size, self.action_space.n)
+        self.critic = LinearCriticHead(self._hidden_size)
+
+    def create_aux_models(self, obs_embed_size: int, action_embed_size: int):
+        if self.auxiliary_uuids is None:
+            return
+        aux_models = OrderedDict()
+        for aux_uuid in self.auxiliary_uuids:
+            aux_models[aux_uuid] = AuxiliaryModel(
+                aux_uuid=aux_uuid,
+                action_dim=self.action_space.n,
+                obs_embed_dim=obs_embed_size,
+                belief_dim=self._hidden_size,
+                action_embed_size=action_embed_size,
+            )
+
+        self.aux_models = nn.ModuleDict(aux_models)
+
+    @property
+    def num_recurrent_layers(self):
+        """Number of recurrent hidden layers."""
+        return list(self.state_encoders.values())[0].num_recurrent_layers
+
+    @property
+    def recurrent_hidden_state_size(self):
+        """The recurrent hidden state size of a single model.
+        """
+        return self._hidden_size
+
+    def _recurrent_memory_specification(self):
+        return {
+            memory_key: (
+                (
+                    ("layer", self.num_recurrent_layers),
+                    ("sampler", None),
+                    ("hidden", self.recurrent_hidden_state_size),
+                ),
+                torch.float32,
+            ) for memory_key in self.belief_names
+        }
+
+    def forward_encoder(self, observations: ObservationType)-> torch.FloatTensor:
+        raise NotImplementedError("Obs Encoder Not Implemented")
+
+    def fuse_beliefs(self, 
+        beliefs_dict: Dict[str, torch.FloatTensor],
+        obs_embeds: torch.FloatTensor,
+    )-> Tuple[torch.FloatTensor, Optional[torch.FloatTensor]]:
+        total_beliefs = torch.stack(list(beliefs_dict.values()), dim=-1) # (T, N, H, k)
+        
+        if self.multiple_beliefs: # call the fusion model
+            return self.fusion_model(
+                    total_beliefs=total_beliefs,
+                    obs_embeds=obs_embeds
+                    )
+        # single belief
+        beliefs = total_beliefs.squeeze(-1) # (T,N,H)
+        return beliefs, None
+
+    def forward(  # type:ignore
+        self,
+        observations: ObservationType,
+        memory: Memory,
+        prev_actions: torch.Tensor,
+        masks: torch.FloatTensor,
+    ) -> Tuple[ActorCriticOutput[DistributionType], Optional[Memory]]:
+
+        # 1.1 use perception model (i.e. encoder) to get observation embeddings 
+        obs_embeds = self.forward_encoder(observations)
+        # 1.2 use embedding model to get prev_action embeddings
+        prev_actions_embeds = self.prev_action_embedder(prev_actions).to(obs_embeds)
+        joint_embeds = torch.cat((obs_embeds, prev_actions_embeds), dim=-1) # (T, N, *)
+
+        # 2. use RNNs to get single/multiple beliefs
+        beliefs_dict = {}
+        for key, model in self.state_encoders.items():
+            beliefs_dict[key], rnn_hidden_states = model(
+                joint_embeds, memory.tensor(key), masks
+            )
+            memory.set_tensor(key, rnn_hidden_states) # update memory here
+
+        # 3. fuse beliefs for multiple belief models
+        beliefs, task_weights = self.fuse_beliefs(beliefs_dict, obs_embeds) # fused beliefs
+
+        # 4. prepare output
+        extras = {
+            aux_uuid: {
+                "beliefs": (beliefs_dict[aux_uuid] 
+                    if self.multiple_beliefs else beliefs),
+                "obs_embeds": obs_embeds,
+                "aux_model": (self.aux_models[aux_uuid]
+                     if aux_uuid in self.aux_models else None),
+            } 
+            for aux_uuid in self.auxiliary_uuids
+        } if self.auxiliary_uuids is not None else {}
+
+        if self.multiple_beliefs:
+            extras[TaskWeightsLoss.UUID] = task_weights
+
+        actor_critic_output = ActorCriticOutput(
+                distributions=self.actor(beliefs),
+                values=self.critic(beliefs),
+                extras=extras,
+            )
+        
+        return actor_critic_output, memory
+

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, Optional
+from typing import Tuple, Dict, Optional, List
 from allenact.utils.system import get_logger
 from collections import OrderedDict
 
@@ -109,6 +109,17 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
                 len(self.belief_names), self.belief_names
             )
         )
+
+    def load_state_dict(self, state_dict):
+        new_state_dict = state_dict.copy()
+        for key in state_dict.keys():
+            if "state_encoder." in key: # old key name
+                new_key = key.replace("state_encoder.", "state_encoders.single_belief.")
+            else:
+                new_key = key
+            new_state_dict[new_key] = state_dict[key]
+
+        return super().load_state_dict(new_state_dict, strict=False) # compatible in keys
 
     def create_actorcritic_head(self):
         self.actor = LinearActorHead(self._hidden_size, self.action_space.n)

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -23,13 +23,16 @@ from allenact.embodiedai.aux_losses.losses import MultiAuxTaskNegEntropyLoss
 
 from typing import TypeVar
 from allenact.embodiedai.models.fusion_models import Fusion
+
 FusionType = TypeVar("FusionType", bound=Fusion)
 
+
 class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
-    '''
+    """
     Base class of visual navigation / manipulation (or broadly, embodied AI) model.
     `forward_encoder` function requires implementation.
-    '''
+    """
+
     def __init__(
         self,
         action_space: gym.spaces.Discrete,

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -50,7 +50,12 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
         self.auxiliary_uuids = auxiliary_uuids
         if isinstance(self.auxiliary_uuids, list) and len(self.auxiliary_uuids) == 0:
             self.auxiliary_uuids = None
-        self.aux_models = None
+
+        # Define the placeholders in init function
+        self.state_encoders: nn.ModuleDict
+        self.aux_models: nn.ModuleDict
+        self.actor: LinearActorHead
+        self.critic: LinearCriticHead
 
     def create_state_encoders(
         self,
@@ -188,7 +193,7 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
         # 1.1 use perception model (i.e. encoder) to get observation embeddings
         obs_embeds = self.forward_encoder(observations)
         # 1.2 use embedding model to get prev_action embeddings
-        prev_actions_embeds = self.prev_action_embedder(prev_actions).to(obs_embeds)
+        prev_actions_embeds = self.prev_action_embedder(prev_actions)
         joint_embeds = torch.cat((obs_embeds, prev_actions_embeds), dim=-1)  # (T, N, *)
 
         # 2. use RNNs to get single/multiple beliefs

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -166,6 +166,21 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
         prev_actions: torch.Tensor,
         masks: torch.FloatTensor,
     ) -> Tuple[ActorCriticOutput[DistributionType], Optional[Memory]]:
+        """
+        Processes input batched observations to produce new actor and critic
+        values. Processes input batched observations (along with prior hidden
+        states, previous actions, and masks denoting which recurrent hidden
+        states should be masked) and returns an `ActorCriticOutput` object
+        containing the model's policy (distribution over actions) and
+        evaluation of the current state (value).
+        # Parameters
+        observations : Batched input observations.
+        memory : `Memory` containing the hidden states from initial timepoints.
+        prev_actions : Tensor of previous actions taken.
+        masks : Masks applied to hidden states. See `RNNStateEncoder`.
+        # Returns
+        Tuple of the `ActorCriticOutput` and recurrent hidden state.
+        """
 
         # 1.1 use perception model (i.e. encoder) to get observation embeddings
         obs_embeds = self.forward_encoder(observations)

--- a/allenact/embodiedai/models/visual_nav_models.py
+++ b/allenact/embodiedai/models/visual_nav_models.py
@@ -113,13 +113,15 @@ class VisualNavActorCritic(ActorCriticModel[CategoricalDistr]):
     def load_state_dict(self, state_dict):
         new_state_dict = state_dict.copy()
         for key in state_dict.keys():
-            if "state_encoder." in key: # old key name
+            if "state_encoder." in key:  # old key name
                 new_key = key.replace("state_encoder.", "state_encoders.single_belief.")
             else:
                 new_key = key
             new_state_dict[new_key] = state_dict[key]
 
-        return super().load_state_dict(new_state_dict, strict=False) # compatible in keys
+        return super().load_state_dict(
+            new_state_dict, strict=False
+        )  # compatible in keys
 
     def create_actorcritic_head(self):
         self.actor = LinearActorHead(self._hidden_size, self.action_space.n)

--- a/allenact/main.py
+++ b/allenact/main.py
@@ -85,9 +85,11 @@ def get_argument_parser():
     parser.add_argument(
         "--save_dir_fmt",
         required=False,
-        type=str,
-        default=SaveDirFormat.FLAT,
-        help="check SaveDirFormat",
+        type=lambda s: SaveDirFormat[s.upper()],
+        default="flat",
+        help="The file structure to use when saving results from allenact."
+        " See documentation o f`SaveDirFormat` for more details."
+        " Allowed values are ('flat' and 'nested'). Default: 'flat'.",
     )
 
     parser.add_argument(
@@ -117,6 +119,13 @@ def get_argument_parser():
         "\nIf you'd like to only evaluate a subset of the checkpoints specified by the above directory/glob"
         " (e.g. every checkpoint saved after 5mil steps) you'll likely want to use the `--approx_ckpt_step_interval`"
         " flag.",
+    )
+    parser.add_argument(
+        "--infer_output_dir",
+        dest="infer_output_dir",
+        action="store_true",
+        required=False,
+        help="applied when evaluating checkpoint(s) in nested save_dir_fmt: if specified, the output dir will be inferred from checkpoint path.",
     )
     parser.add_argument(
         "--approx_ckpt_step_interval",
@@ -452,6 +461,7 @@ def main():
             machine_id=args.machine_id,
         ).start_test(
             checkpoint_path_dir_or_pattern=args.checkpoint,
+            infer_output_dir=args.infer_output_dir,
             approx_ckpt_step_interval=args.approx_ckpt_step_interval,
             max_sampler_processes_per_worker=args.max_sampler_processes_per_worker,
             inference_expert=args.test_expert,

--- a/allenact/main.py
+++ b/allenact/main.py
@@ -12,7 +12,11 @@ from typing import Dict, Tuple, List, Optional, Type
 from setproctitle import setproctitle as ptitle
 
 from allenact import __version__
-from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner, _CONFIG_KWARGS_STR, SaveDirFormat
+from allenact.algorithms.onpolicy_sync.runner import (
+    OnPolicyRunner,
+    _CONFIG_KWARGS_STR,
+    SaveDirFormat,
+)
 from allenact.base_abstractions.experiment_config import ExperimentConfig
 from allenact.utils.system import get_logger, init_logging, HUMAN_LOG_LEVELS
 

--- a/allenact/main.py
+++ b/allenact/main.py
@@ -12,7 +12,7 @@ from typing import Dict, Tuple, List, Optional, Type
 from setproctitle import setproctitle as ptitle
 
 from allenact import __version__
-from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner, _CONFIG_KWARGS_STR
+from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner, _CONFIG_KWARGS_STR, SaveDirFormat
 from allenact.base_abstractions.experiment_config import ExperimentConfig
 from allenact.utils.system import get_logger, init_logging, HUMAN_LOG_LEVELS
 
@@ -76,6 +76,14 @@ def get_argument_parser():
         type=str,
         default="experiment_output",
         help="experiment output folder",
+    )
+
+    parser.add_argument(
+        "--save_dir_fmt",
+        required=False,
+        type=str,
+        default=SaveDirFormat.FLAT,
+        help="check SaveDirFormat",
     )
 
     parser.add_argument(
@@ -406,6 +414,7 @@ def main():
         OnPolicyRunner(
             config=cfg,
             output_dir=args.output_dir,
+            save_dir_fmt=args.save_dir_fmt,
             loaded_config_src_files=srcs,
             seed=args.seed,
             mode="train",
@@ -426,6 +435,7 @@ def main():
         OnPolicyRunner(
             config=cfg,
             output_dir=args.output_dir,
+            save_dir_fmt=args.save_dir_fmt,
             loaded_config_src_files=srcs,
             seed=args.seed,
             mode="test",

--- a/allenact/utils/model_utils.py
+++ b/allenact/utils/model_utils.py
@@ -228,11 +228,12 @@ class FeatureEmbedding(nn.Module):
         self.output_size = output_size
         if self.output_size != 0:
             self.fc = nn.Embedding(input_size, output_size)
-        else:
-            self.fc = None
+        else:  # automatically be moved to a device
+            self.null_embedding: torch.Tensor
+            self.register_buffer("null_embedding", torch.zeros(0,), persistent=False)
 
     def forward(self, inputs):
         if self.output_size != 0:
             return self.fc(inputs)
-        else:  # useful for concat, to be move to device
-            return torch.zeros(0,)
+        else:
+            return self.null_embedding

--- a/allenact/utils/model_utils.py
+++ b/allenact/utils/model_utils.py
@@ -217,21 +217,22 @@ def simple_linear_weights_init(m):
         if m.bias is not None:
             m.bias.data.fill_(0)
 
+
 class FeatureEmbedding(nn.Module):
-	""" A wrapper of nn.Embedding but support zero output
+    """ A wrapper of nn.Embedding but support zero output
 	Used for extracting features for actions/rewards
 	"""
 
-	def __init__(self, input_size, output_size):
-		super().__init__()
-		self.output_size = output_size
-		if self.output_size != 0:
-			self.fc = nn.Embedding(input_size, output_size) 
-		else:
-			self.fc = None
+    def __init__(self, input_size, output_size):
+        super().__init__()
+        self.output_size = output_size
+        if self.output_size != 0:
+            self.fc = nn.Embedding(input_size, output_size)
+        else:
+            self.fc = None
 
-	def forward(self, inputs):
-		if self.output_size != 0:
-			return self.fc(inputs)
-		else: # useful for concat, to be move to device
-			return torch.zeros(0, )
+    def forward(self, inputs):
+        if self.output_size != 0:
+            return self.fc(inputs)
+        else:  # useful for concat, to be move to device
+            return torch.zeros(0,)

--- a/allenact/utils/model_utils.py
+++ b/allenact/utils/model_utils.py
@@ -216,3 +216,22 @@ def simple_linear_weights_init(m):
         m.weight.data.uniform_(-w_bound, w_bound)
         if m.bias is not None:
             m.bias.data.fill_(0)
+
+class FeatureEmbedding(nn.Module):
+	""" A wrapper of nn.Embedding but support zero output
+	Used for extracting features for actions/rewards
+	"""
+
+	def __init__(self, input_size, output_size):
+		super().__init__()
+		self.output_size = output_size
+		if self.output_size != 0:
+			self.fc = nn.Embedding(input_size, output_size) 
+		else:
+			self.fc = None
+
+	def forward(self, inputs):
+		if self.output_size != 0:
+			return self.fc(inputs)
+		else: # useful for concat, to be move to device
+			return torch.zeros(0, )

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -10,7 +10,7 @@ from allenact.algorithms.onpolicy_sync.losses import PPO
 from allenact.algorithms.onpolicy_sync.losses.ppo import PPOConfig
 
 from allenact.embodiedai.aux_losses.losses import (
-    TaskWeightsLoss,
+    MultiAuxTaskNegEntropyLoss,
     InverseDynamicsLoss,
     TemporalDistanceLoss,
     CPCA1Loss,
@@ -112,8 +112,8 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
         named_losses["ppo_loss"] = (PPO(**PPOConfig), 1.0)
 
         if cls.multiple_beliefs:  # add weight entropy loss automatically
-            named_losses[TaskWeightsLoss.UUID] = (
-                TaskWeightsLoss(cls.AUXILIARY_UUIDS),
+            named_losses[MultiAuxTaskNegEntropyLoss.UUID] = (
+                MultiAuxTaskNegEntropyLoss(cls.AUXILIARY_UUIDS),
                 0.01,
             )
 

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -46,10 +46,10 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
         # CPCA16Loss.UUID,
     ]
 
-    add_prev_actions = False
+    ADD_PREV_ACTIONS = False
 
-    multiple_beliefs = False
-    beliefs_fusion = (  # choose one
+    MULTIPLE_BELIEFS = False
+    BELIEF_FUSION = (  # choose one
         None
         # AttentiveFusion.UUID
         # AverageFusion.UUID
@@ -142,7 +142,7 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
             {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
         )
 
-        if cls.multiple_beliefs:  # add weight entropy loss automatically
+        if cls.MULTIPLE_BELIEFS:  # add weight entropy loss automatically
             named_losses[MultiAuxTaskNegEntropyLoss.UUID] = (
                 MultiAuxTaskNegEntropyLoss(cls.AUXILIARY_UUIDS),
                 0.01,

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -50,7 +50,8 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
 
     multiple_beliefs = False
     beliefs_fusion = (  # choose one
-        AttentiveFusion.UUID
+        None
+        # AttentiveFusion.UUID
         # AverageFusion.UUID
         # SoftmaxFusion.UUID
     )

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -1,9 +1,30 @@
+from typing import Dict, Tuple
 import torch
 import torch.optim as optim
 from torch.optim.lr_scheduler import LambdaLR
 
+from allenact.algorithms.onpolicy_sync.losses.abstract_loss import (
+    AbstractActorCriticLoss,
+)
 from allenact.algorithms.onpolicy_sync.losses import PPO
 from allenact.algorithms.onpolicy_sync.losses.ppo import PPOConfig
+
+from allenact.embodiedai.aux_losses.losses import (
+    TaskWeightsLoss,
+    InverseDynamicsLoss,
+    TemporalDistanceLoss,
+    CPCA1Loss,
+    CPCA2Loss,
+    CPCA4Loss,
+    CPCA8Loss,
+    CPCA16Loss,
+)
+from allenact.embodiedai.models.fusion_models import (
+    AverageFusion,
+    SoftmaxFusion,
+    AttentiveFusion,
+)
+
 from allenact.utils.experiment_utils import (
     Builder,
     PipelineStage,
@@ -14,7 +35,29 @@ from projects.objectnav_baselines.experiments.objectnav_base import ObjectNavBas
 
 
 class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
-    def training_pipeline(self, **kwargs):
+    # selected auxiliary uuids
+    ## if comment all the keys, then it's vanilla DD-PPO
+    AUXILIARY_UUIDS = [
+        # InverseDynamicsLoss.UUID,
+        # TemporalDistanceLoss.UUID,
+        # CPCA1Loss.UUID,
+        # CPCA4Loss.UUID,
+        # CPCA8Loss.UUID,
+        # CPCA16Loss.UUID,
+    ]
+
+    add_prev_actions = False
+
+    multiple_beliefs = False
+    beliefs_fusion = (  # choose one
+        AttentiveFusion.UUID
+        # AverageFusion.UUID
+        # SoftmaxFusion.UUID
+    )
+
+    @classmethod
+    def training_pipeline(cls, **kwargs):
+        # PPO
         ppo_steps = int(300000000)
         lr = 3e-4
         num_mini_batch = 1
@@ -26,6 +69,54 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
         use_gae = True
         gae_lambda = 0.95
         max_grad_norm = 0.5
+
+        # auxliary losses
+        aux_loss_total_weight = 2.0
+
+        # Total losses
+        total_aux_losses: Dict[str, Tuple[AbstractActorCriticLoss, float]] = {
+            InverseDynamicsLoss.UUID: (
+                InverseDynamicsLoss(
+                    subsample_rate=0.2, subsample_min_num=10,  # TODO: test its effects
+                ),
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            TemporalDistanceLoss.UUID: (
+                TemporalDistanceLoss(
+                    num_pairs=8, epsiode_len_min=5,  # TODO: test its effects
+                ),
+                0.2 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA1Loss.UUID: (
+                CPCA1Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA2Loss.UUID: (
+                CPCA2Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA4Loss.UUID: (
+                CPCA4Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA8Loss.UUID: (
+                CPCA8Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA16Loss.UUID: (
+                CPCA16Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+        }
+        named_losses = {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
+        named_losses["ppo_loss"] = (PPO(**PPOConfig), 1.0)
+
+        if cls.multiple_beliefs:  # add weight entropy loss automatically
+            named_losses[TaskWeightsLoss.UUID] = (
+                TaskWeightsLoss(cls.AUXILIARY_UUIDS),
+                0.01,
+            )
+
         return TrainingPipeline(
             save_interval=save_interval,
             metric_accumulate_interval=log_interval,
@@ -34,13 +125,17 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
             update_repeats=update_repeats,
             max_grad_norm=max_grad_norm,
             num_steps=num_steps,
-            named_losses={"ppo_loss": PPO(**PPOConfig)},
+            named_losses={key: val[0] for key, val in named_losses.items()},
             gamma=gamma,
             use_gae=use_gae,
             gae_lambda=gae_lambda,
-            advance_scene_rollout_period=self.ADVANCE_SCENE_ROLLOUT_PERIOD,
+            advance_scene_rollout_period=cls.ADVANCE_SCENE_ROLLOUT_PERIOD,
             pipeline_stages=[
-                PipelineStage(loss_names=["ppo_loss"], max_stage_steps=ppo_steps)
+                PipelineStage(
+                    loss_names=list(named_losses.keys()),
+                    max_stage_steps=ppo_steps,
+                    loss_weights=[val[1] for val in named_losses.values()],
+                )
             ],
             lr_scheduler_builder=Builder(
                 LambdaLR, {"lr_lambda": LinearDecay(steps=ppo_steps)}

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -19,6 +19,8 @@ from allenact.embodiedai.aux_losses.losses import (
     CPCA8Loss,
     CPCA16Loss,
 )
+
+# noinspection PyUnresolvedReferences
 from allenact.embodiedai.models.fusion_models import (
     AverageFusion,
     SoftmaxFusion,

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -97,7 +97,7 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
                 LambdaLR, {"lr_lambda": LinearDecay(steps=ppo_steps)}
             ),
         )
-    
+
     @classmethod
     def _update_with_auxiliary_losses(cls, named_losses):
         # auxliary losses

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_ddppo.py
@@ -56,8 +56,7 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
         # SoftmaxFusion.UUID
     )
 
-    @classmethod
-    def training_pipeline(cls, **kwargs):
+    def training_pipeline(self, **kwargs):
         # PPO
         ppo_steps = int(300000000)
         lr = 3e-4
@@ -71,6 +70,36 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
         gae_lambda = 0.95
         max_grad_norm = 0.5
 
+        named_losses = {"ppo_loss": (PPO(**PPOConfig), 1.0)}
+        named_losses = self._update_with_auxiliary_losses(named_losses)
+
+        return TrainingPipeline(
+            save_interval=save_interval,
+            metric_accumulate_interval=log_interval,
+            optimizer_builder=Builder(optim.Adam, dict(lr=lr)),
+            num_mini_batch=num_mini_batch,
+            update_repeats=update_repeats,
+            max_grad_norm=max_grad_norm,
+            num_steps=num_steps,
+            named_losses={key: val[0] for key, val in named_losses.items()},
+            gamma=gamma,
+            use_gae=use_gae,
+            gae_lambda=gae_lambda,
+            advance_scene_rollout_period=self.ADVANCE_SCENE_ROLLOUT_PERIOD,
+            pipeline_stages=[
+                PipelineStage(
+                    loss_names=list(named_losses.keys()),
+                    max_stage_steps=ppo_steps,
+                    loss_weights=[val[1] for val in named_losses.values()],
+                )
+            ],
+            lr_scheduler_builder=Builder(
+                LambdaLR, {"lr_lambda": LinearDecay(steps=ppo_steps)}
+            ),
+        )
+    
+    @classmethod
+    def _update_with_auxiliary_losses(cls, named_losses):
         # auxliary losses
         aux_loss_total_weight = 2.0
 
@@ -109,8 +138,9 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
                 0.05 * aux_loss_total_weight,  # should times 2
             ),
         }
-        named_losses = {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
-        named_losses["ppo_loss"] = (PPO(**PPOConfig), 1.0)
+        named_losses.update(
+            {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
+        )
 
         if cls.multiple_beliefs:  # add weight entropy loss automatically
             named_losses[MultiAuxTaskNegEntropyLoss.UUID] = (
@@ -118,27 +148,4 @@ class ObjectNavMixInPPOConfig(ObjectNavBaseConfig):
                 0.01,
             )
 
-        return TrainingPipeline(
-            save_interval=save_interval,
-            metric_accumulate_interval=log_interval,
-            optimizer_builder=Builder(optim.Adam, dict(lr=lr)),
-            num_mini_batch=num_mini_batch,
-            update_repeats=update_repeats,
-            max_grad_norm=max_grad_norm,
-            num_steps=num_steps,
-            named_losses={key: val[0] for key, val in named_losses.items()},
-            gamma=gamma,
-            use_gae=use_gae,
-            gae_lambda=gae_lambda,
-            advance_scene_rollout_period=cls.ADVANCE_SCENE_ROLLOUT_PERIOD,
-            pipeline_stages=[
-                PipelineStage(
-                    loss_names=list(named_losses.keys()),
-                    max_stage_steps=ppo_steps,
-                    loss_weights=[val[1] for val in named_losses.values()],
-                )
-            ],
-            lr_scheduler_builder=Builder(
-                LambdaLR, {"lr_lambda": LinearDecay(steps=ppo_steps)}
-            ),
-        )
+        return named_losses

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_rawgru.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_rawgru.py
@@ -1,0 +1,59 @@
+from typing import Sequence, Union
+
+import gym
+import torch.nn as nn
+
+from allenact.base_abstractions.preprocessor import Preprocessor
+from allenact.embodiedai.sensors.vision_sensors import RGBSensor, DepthSensor
+from allenact.utils.experiment_utils import Builder
+from allenact_plugins.ithor_plugin.ithor_sensors import GoalObjectTypeThorSensor
+from allenact_plugins.robothor_plugin.robothor_tasks import ObjectNavTask
+from projects.objectnav_baselines.experiments.objectnav_base import ObjectNavBaseConfig
+from projects.objectnav_baselines.models.object_nav_models import ObjectNavActorCritic
+
+
+class ObjectNavMixInRawGRUConfig(ObjectNavBaseConfig):
+    """
+    No ResNet preprocessor, using Raw Image as input, and learn a ResNet as encoder 
+    """
+
+    @classmethod
+    def preprocessors(cls) -> Sequence[Union[Preprocessor, Builder[Preprocessor]]]:
+        return []
+
+    BACKBONE = (
+        "resnet18"
+        # "simple_cnn"
+    )
+
+    @classmethod
+    def create_model(cls, **kwargs) -> nn.Module:
+        rgb_uuid = next((s.uuid for s in cls.SENSORS if isinstance(s, RGBSensor)), None)
+        depth_uuid = next(
+            (s.uuid for s in cls.SENSORS if isinstance(s, DepthSensor)), None
+        )
+        goal_sensor_uuid = next(
+            (s.uuid for s in cls.SENSORS if isinstance(s, GoalObjectTypeThorSensor)),
+            None,
+        )
+
+        return ObjectNavActorCritic(
+            action_space=gym.spaces.Discrete(len(ObjectNavTask.class_action_names())),
+            observation_space=kwargs["sensor_preprocessor_graph"].observation_spaces,
+            rgb_uuid=rgb_uuid,
+            depth_uuid=depth_uuid,
+            goal_sensor_uuid=goal_sensor_uuid,
+            hidden_size=192
+            if cls.multiple_beliefs and len(cls.AUXILIARY_UUIDS) > 1
+            else 512,
+            backbone=cls.BACKBONE,
+            resnet_baseplanes=32,
+            object_type_embedding_dim=32,
+            num_rnn_layers=1,
+            rnn_type="GRU",
+            add_prev_actions=cls.add_prev_actions,
+            action_embed_size=6,
+            auxiliary_uuids=cls.AUXILIARY_UUIDS,
+            multiple_beliefs=cls.multiple_beliefs,
+            beliefs_fusion=cls.beliefs_fusion,
+        )

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_rawgru.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_rawgru.py
@@ -22,7 +22,7 @@ class ObjectNavMixInRawGRUConfig(ObjectNavBaseConfig):
         return []
 
     BACKBONE = (
-        "resnet18"
+        "gnresnet18"
         # "simple_cnn"
     )
 

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_unfrozenresnet_gru.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_unfrozenresnet_gru.py
@@ -44,16 +44,16 @@ class ObjectNavMixInUnfrozenResNetGRUConfig(ObjectNavBaseConfig):
             depth_uuid=depth_uuid,
             goal_sensor_uuid=goal_sensor_uuid,
             hidden_size=192
-            if cls.multiple_beliefs and len(cls.AUXILIARY_UUIDS) > 1
+            if cls.MULTIPLE_BELIEFS and len(cls.AUXILIARY_UUIDS) > 1
             else 512,
             backbone=cls.BACKBONE,
             resnet_baseplanes=32,
             object_type_embedding_dim=32,
             num_rnn_layers=1,
             rnn_type="GRU",
-            add_prev_actions=cls.add_prev_actions,
+            add_prev_actions=cls.ADD_PREV_ACTIONS,
             action_embed_size=6,
             auxiliary_uuids=cls.AUXILIARY_UUIDS,
-            multiple_beliefs=cls.multiple_beliefs,
-            beliefs_fusion=cls.beliefs_fusion,
+            multiple_beliefs=cls.MULTIPLE_BELIEFS,
+            beliefs_fusion=cls.BELIEF_FUSION,
         )

--- a/projects/objectnav_baselines/experiments/objectnav_mixin_unfrozenresnet_gru.py
+++ b/projects/objectnav_baselines/experiments/objectnav_mixin_unfrozenresnet_gru.py
@@ -12,7 +12,7 @@ from projects.objectnav_baselines.experiments.objectnav_base import ObjectNavBas
 from projects.objectnav_baselines.models.object_nav_models import ObjectNavActorCritic
 
 
-class ObjectNavMixInRawGRUConfig(ObjectNavBaseConfig):
+class ObjectNavMixInUnfrozenResNetGRUConfig(ObjectNavBaseConfig):
     """
     No ResNet preprocessor, using Raw Image as input, and learn a ResNet as encoder 
     """

--- a/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_rawgru_ddppo.py
+++ b/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_rawgru_ddppo.py
@@ -1,0 +1,36 @@
+from allenact_plugins.ithor_plugin.ithor_sensors import (
+    RGBSensorThor,
+    GoalObjectTypeThorSensor,
+)
+from projects.objectnav_baselines.experiments.objectnav_mixin_ddppo import (
+    ObjectNavMixInPPOConfig,
+)
+from projects.objectnav_baselines.experiments.objectnav_mixin_rawgru import (
+    ObjectNavMixInRawGRUConfig,
+)
+from projects.objectnav_baselines.experiments.robothor.objectnav_robothor_base import (
+    ObjectNavRoboThorBaseConfig,
+)
+
+
+class ObjectNavRoboThorRGBPPOExperimentConfig(
+    ObjectNavRoboThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInRawGRUConfig,
+):
+    """An Object Navigation experiment configuration in RoboThor with RGB
+    input without preprocessing by frozen ResNet (instead, a trainable ResNet)."""
+
+    SENSORS = [
+        RGBSensorThor(
+            height=ObjectNavRoboThorBaseConfig.SCREEN_SIZE,
+            width=ObjectNavRoboThorBaseConfig.SCREEN_SIZE,
+            use_resnet_normalization=True,
+            uuid="rgb_lowres",
+        ),
+        GoalObjectTypeThorSensor(
+            object_types=ObjectNavRoboThorBaseConfig.TARGET_TYPES,
+        ),
+    ]
+
+    @classmethod
+    def tag(cls):
+        return "Objectnav-RoboTHOR-RGB-RawGRU-DDPPO"

--- a/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_unfrozenresnet_gru_ddppo.py
+++ b/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_unfrozenresnet_gru_ddppo.py
@@ -5,8 +5,8 @@ from allenact_plugins.ithor_plugin.ithor_sensors import (
 from projects.objectnav_baselines.experiments.objectnav_mixin_ddppo import (
     ObjectNavMixInPPOConfig,
 )
-from projects.objectnav_baselines.experiments.objectnav_mixin_rawgru import (
-    ObjectNavMixInRawGRUConfig,
+from projects.objectnav_baselines.experiments.objectnav_mixin_unfrozenresnet_gru import (
+    ObjectNavMixInUnfrozenResNetGRUConfig,
 )
 from projects.objectnav_baselines.experiments.robothor.objectnav_robothor_base import (
     ObjectNavRoboThorBaseConfig,
@@ -14,7 +14,7 @@ from projects.objectnav_baselines.experiments.robothor.objectnav_robothor_base i
 
 
 class ObjectNavRoboThorRGBPPOExperimentConfig(
-    ObjectNavRoboThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInRawGRUConfig,
+    ObjectNavRoboThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInUnfrozenResNetGRUConfig,
 ):
     """An Object Navigation experiment configuration in RoboThor with RGB
     input without preprocessing by frozen ResNet (instead, a trainable ResNet)."""
@@ -33,4 +33,4 @@ class ObjectNavRoboThorRGBPPOExperimentConfig(
 
     @classmethod
     def tag(cls):
-        return "Objectnav-RoboTHOR-RGB-RawGRU-DDPPO"
+        return "Objectnav-RoboTHOR-RGB-UnfrozenResNet-GRU-DDPPO"

--- a/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_unfrozenresnet_gru_ddppo.py
+++ b/projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_unfrozenresnet_gru_ddppo.py
@@ -14,7 +14,9 @@ from projects.objectnav_baselines.experiments.robothor.objectnav_robothor_base i
 
 
 class ObjectNavRoboThorRGBPPOExperimentConfig(
-    ObjectNavRoboThorBaseConfig, ObjectNavMixInPPOConfig, ObjectNavMixInUnfrozenResNetGRUConfig,
+    ObjectNavRoboThorBaseConfig,
+    ObjectNavMixInPPOConfig,
+    ObjectNavMixInUnfrozenResNetGRUConfig,
 ):
     """An Object Navigation experiment configuration in RoboThor with RGB
     input without preprocessing by frozen ResNet (instead, a trainable ResNet)."""

--- a/projects/objectnav_baselines/models/object_nav_models.py
+++ b/projects/objectnav_baselines/models/object_nav_models.py
@@ -51,7 +51,7 @@ class ObjectNavActorCritic(VisualNavActorCritic):
         # below are custom params
         rgb_uuid: Optional[str] = None,
         depth_uuid: Optional[str] = None,
-        object_type_embedding_dim=32,
+        object_type_embedding_dim=8,
         trainable_masked_hidden_state: bool = False,
         # perception backbone params,
         backbone="gnresnet18",
@@ -115,7 +115,6 @@ class ObjectNavActorCritic(VisualNavActorCritic):
         )
 
         self.train()
-        get_logger().info(self)
 
     @property
     def is_blind(self) -> bool:
@@ -227,19 +226,12 @@ class ResnetTensorObjectNavActorCritic(VisualNavActorCritic):
         )
 
         self.train()
-        get_logger().info(self)
 
     @property
     def is_blind(self) -> bool:
         """True if the model is blind (e.g. neither 'depth' or 'rgb' is an
         input observation type)."""
         return self.goal_visual_encoder.is_blind
-
-    def get_object_type_encoding(
-        self, observations: Dict[str, torch.FloatTensor]
-    ) -> torch.FloatTensor:
-        """Get the object type encoding from input batched observations. Redundant"""
-        return self.goal_visual_encoder.get_object_type_encoding(observations)
 
     def forward_encoder(self, observations: ObservationType) -> torch.FloatTensor:
         return self.goal_visual_encoder(observations)

--- a/projects/objectnav_baselines/models/object_nav_models.py
+++ b/projects/objectnav_baselines/models/object_nav_models.py
@@ -4,7 +4,6 @@ Object navigation is currently available as a Task in AI2-THOR and
 Facebook's Habitat.
 """
 from typing import Tuple, Dict, Optional, cast, List
-from allenact.utils.system import get_logger
 
 import gym
 import torch

--- a/projects/objectnav_baselines/models/object_nav_models.py
+++ b/projects/objectnav_baselines/models/object_nav_models.py
@@ -14,7 +14,7 @@ from gym.spaces.dict import Dict as SpaceDict
 from allenact.algorithms.onpolicy_sync.policy import ObservationType
 from allenact.embodiedai.models.basic_models import SimpleCNN
 import allenact.embodiedai.models.resnet as resnet
-from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic
+from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic, FusionType
 
 
 class ObjectNavActorCritic(VisualNavActorCritic):
@@ -46,7 +46,7 @@ class ObjectNavActorCritic(VisualNavActorCritic):
         action_embed_size=6,
         # Aux loss
         multiple_beliefs=False,
-        beliefs_fusion: Optional[str] = None,
+        beliefs_fusion: Optional[FusionType] = None,
         auxiliary_uuids: Optional[List[str]] = None,
         # below are custom params
         rgb_uuid: Optional[str] = None,
@@ -166,7 +166,7 @@ class ResnetTensorObjectNavActorCritic(VisualNavActorCritic):
         add_prev_actions=False,
         action_embed_size=6,
         multiple_beliefs=False,
-        beliefs_fusion: Optional[str] = None,
+        beliefs_fusion: Optional[FusionType] = None,
         auxiliary_uuids: Optional[List[str]] = None,
         # custom params
         rgb_resnet_preprocessor_uuid: Optional[str] = None,

--- a/projects/objectnav_baselines/models/object_nav_models.py
+++ b/projects/objectnav_baselines/models/object_nav_models.py
@@ -54,7 +54,7 @@ class ObjectNavActorCritic(VisualNavActorCritic):
         object_type_embedding_dim=32,
         trainable_masked_hidden_state: bool = False,
         # perception backbone params,
-        backbone="resnet18",
+        backbone="gnresnet18",
         resnet_baseplanes=32,
     ):
         """Initializer.
@@ -83,7 +83,7 @@ class ObjectNavActorCritic(VisualNavActorCritic):
                 depth_uuid=depth_uuid,
             )
         else:  # resnet family
-            self.visual_encoder = resnet.ResNetEncoder(
+            self.visual_encoder = resnet.GroupNormResNetEncoder(
                 observation_space=observation_space,
                 output_size=hidden_size,
                 rgb_uuid=rgb_uuid,

--- a/projects/objectnav_baselines/models/object_nav_models.py
+++ b/projects/objectnav_baselines/models/object_nav_models.py
@@ -14,7 +14,10 @@ from gym.spaces.dict import Dict as SpaceDict
 from allenact.algorithms.onpolicy_sync.policy import ObservationType
 from allenact.embodiedai.models.basic_models import SimpleCNN
 import allenact.embodiedai.models.resnet as resnet
-from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic, FusionType
+from allenact.embodiedai.models.visual_nav_models import (
+    VisualNavActorCritic,
+    FusionType,
+)
 
 
 class ObjectNavActorCritic(VisualNavActorCritic):

--- a/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
+++ b/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
@@ -17,13 +17,17 @@ except ImportError:
 from allenact_plugins.robothor_plugin.robothor_sensors import GPSCompassSensorRoboThor
 from allenact_plugins.robothor_plugin.robothor_tasks import PointNavTask
 from projects.pointnav_baselines.experiments.pointnav_base import PointNavBaseConfig
-from projects.pointnav_baselines.models.point_nav_models import (
-    PointNavActorCriticSimpleConvRNN,
-)
+from projects.pointnav_baselines.models.point_nav_models import PointNavActorCritic
 
 
 class PointNavMixInSimpleConvGRUConfig(PointNavBaseConfig, ABC):
     """The base config for all iTHOR PPO PointNav experiments."""
+
+    # TODO only tested in roboTHOR Depth
+    BACKBONE = (  # choose one
+        "resnet18"
+        # "simple_cnn"
+    )
 
     @classmethod
     def create_model(cls, **kwargs) -> nn.Module:
@@ -42,15 +46,28 @@ class PointNavMixInSimpleConvGRUConfig(PointNavBaseConfig, ABC):
             None,
         )
 
-        return PointNavActorCriticSimpleConvRNN(
+        return PointNavActorCritic(
+            # Env and Tak
             action_space=gym.spaces.Discrete(len(PointNavTask.class_action_names())),
             observation_space=kwargs["sensor_preprocessor_graph"].observation_spaces,
             rgb_uuid=rgb_uuid,
             depth_uuid=depth_uuid,
             goal_sensor_uuid=goal_sensor_uuid,
-            hidden_size=512,
-            embed_coordinates=False,
-            coordinate_dims=2,
+            # RNN
+            hidden_size=228
+            if cls.multiple_beliefs and len(cls.AUXILIARY_UUIDS) > 1
+            else 512,
             num_rnn_layers=1,
             rnn_type="GRU",
+            add_prev_actions=cls.add_prev_actions,
+            action_embed_size=4,
+            # CNN
+            backbone=cls.BACKBONE,
+            resnet_baseplanes=32,
+            embed_coordinates=False,
+            coordinate_dims=2,
+            # Aux
+            auxiliary_uuids=cls.AUXILIARY_UUIDS,
+            multiple_beliefs=cls.multiple_beliefs,
+            beliefs_fusion=cls.beliefs_fusion,
         )

--- a/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
+++ b/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
@@ -55,11 +55,11 @@ class PointNavMixInSimpleConvGRUConfig(PointNavBaseConfig, ABC):
             goal_sensor_uuid=goal_sensor_uuid,
             # RNN
             hidden_size=228
-            if cls.multiple_beliefs and len(cls.AUXILIARY_UUIDS) > 1
+            if cls.MULTIPLE_BELIEFS and len(cls.AUXILIARY_UUIDS) > 1
             else 512,
             num_rnn_layers=1,
             rnn_type="GRU",
-            add_prev_actions=cls.add_prev_actions,
+            add_prev_actions=cls.ADD_PREV_ACTIONS,
             action_embed_size=4,
             # CNN
             backbone=cls.BACKBONE,
@@ -68,6 +68,6 @@ class PointNavMixInSimpleConvGRUConfig(PointNavBaseConfig, ABC):
             coordinate_dims=2,
             # Aux
             auxiliary_uuids=cls.AUXILIARY_UUIDS,
-            multiple_beliefs=cls.multiple_beliefs,
-            beliefs_fusion=cls.beliefs_fusion,
+            multiple_beliefs=cls.MULTIPLE_BELIEFS,
+            beliefs_fusion=cls.BELIEF_FUSION,
         )

--- a/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
+++ b/projects/pointnav_baselines/experiments/pointnav_mixin_simpleconvgru.py
@@ -25,7 +25,7 @@ class PointNavMixInSimpleConvGRUConfig(PointNavBaseConfig, ABC):
 
     # TODO only tested in roboTHOR Depth
     BACKBONE = (  # choose one
-        "resnet18"
+        "gnresnet18"
         # "simple_cnn"
     )
 

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -11,7 +11,7 @@ from allenact.algorithms.onpolicy_sync.losses.abstract_loss import (
 from allenact.algorithms.onpolicy_sync.losses import PPO
 from allenact.algorithms.onpolicy_sync.losses.ppo import PPOConfig
 from allenact.embodiedai.aux_losses.losses import (
-    TaskWeightsLoss,
+    MultiAuxTaskNegEntropyLoss,
     InverseDynamicsLoss,
     TemporalDistanceLoss,
     CPCA1Loss,
@@ -117,8 +117,8 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
         named_losses["ppo_loss"] = (PPO(**PPOConfig), 1.0)
 
         if cls.multiple_beliefs:  # add weight entropy loss automatically
-            named_losses[TaskWeightsLoss.UUID] = (
-                TaskWeightsLoss(cls.AUXILIARY_UUIDS),
+            named_losses[MultiAuxTaskNegEntropyLoss.UUID] = (
+                MultiAuxTaskNegEntropyLoss(cls.AUXILIARY_UUIDS),
                 0.01,
             )
 

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -48,10 +48,10 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
         # CPCA16Loss.UUID,
     ]
 
-    add_prev_actions = True
+    ADD_PREV_ACTIONS = True
 
-    multiple_beliefs = False
-    beliefs_fusion = (  # choose one
+    MULTIPLE_BELIEFS = False
+    BELIEF_FUSION = (  # choose one
         None
         # AttentiveFusion.UUID
         # AverageFusion.UUID
@@ -146,7 +146,7 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
             {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
         )
 
-        if cls.multiple_beliefs:  # add weight entropy loss automatically
+        if cls.MULTIPLE_BELIEFS:  # add weight entropy loss automatically
             named_losses[MultiAuxTaskNegEntropyLoss.UUID] = (
                 MultiAuxTaskNegEntropyLoss(cls.AUXILIARY_UUIDS),
                 0.01,

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -20,6 +20,8 @@ from allenact.embodiedai.aux_losses.losses import (
     CPCA8Loss,
     CPCA16Loss,
 )
+
+# noinspection PyUnresolvedReferences
 from allenact.embodiedai.models.fusion_models import (
     AverageFusion,
     SoftmaxFusion,

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -1,11 +1,30 @@
 from abc import ABC
+from typing import Dict, Tuple
 
 import torch
 import torch.optim as optim
 from torch.optim.lr_scheduler import LambdaLR
 
+from allenact.algorithms.onpolicy_sync.losses.abstract_loss import (
+    AbstractActorCriticLoss,
+)
 from allenact.algorithms.onpolicy_sync.losses import PPO
 from allenact.algorithms.onpolicy_sync.losses.ppo import PPOConfig
+from allenact.embodiedai.aux_losses.losses import (
+    TaskWeightsLoss,
+    InverseDynamicsLoss,
+    TemporalDistanceLoss,
+    CPCA1Loss,
+    CPCA2Loss,
+    CPCA4Loss,
+    CPCA8Loss,
+    CPCA16Loss,
+)
+from allenact.embodiedai.models.fusion_models import (
+    AverageFusion,
+    SoftmaxFusion,
+    AttentiveFusion,
+)
 from allenact.utils.experiment_utils import (
     Builder,
     PipelineStage,
@@ -18,8 +37,31 @@ from projects.pointnav_baselines.experiments.pointnav_base import PointNavBaseCo
 class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
     """The base config for all iTHOR PPO PointNav experiments."""
 
+    # selected auxiliary uuids
+    ## if comment all the keys, then it's vanilla DD-PPO
+    AUXILIARY_UUIDS = [
+        # InverseDynamicsLoss.UUID,
+        # TemporalDistanceLoss.UUID,
+        # CPCA1Loss.UUID,
+        # CPCA4Loss.UUID,
+        # CPCA8Loss.UUID,
+        # CPCA16Loss.UUID,
+    ]
+
+    add_prev_actions = True
+
+    multiple_beliefs = False
+    beliefs_fusion = (  # choose one
+        AttentiveFusion.UUID
+        # AverageFusion.UUID
+        # SoftmaxFusion.UUID
+    )
+
+    normalize_advantage = False
+
     @classmethod
     def training_pipeline(cls, **kwargs):
+        # PPO
         ppo_steps = int(75000000)
         lr = 3e-4
         num_mini_batch = 1
@@ -31,6 +73,55 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
         use_gae = True
         gae_lambda = 0.95
         max_grad_norm = 0.5
+
+        # auxliary losses
+        aux_loss_total_weight = 2.0
+
+        # Total losses
+        total_aux_losses: Dict[str, Tuple[AbstractActorCriticLoss, float]] = {
+            InverseDynamicsLoss.UUID: (
+                InverseDynamicsLoss(
+                    subsample_rate=0.2, subsample_min_num=10,  # TODO: test its effects
+                ),
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            TemporalDistanceLoss.UUID: (
+                TemporalDistanceLoss(
+                    num_pairs=8, epsiode_len_min=5,  # TODO: test its effects
+                ),
+                0.2 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA1Loss.UUID: (
+                CPCA1Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA2Loss.UUID: (
+                CPCA2Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA4Loss.UUID: (
+                CPCA4Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA8Loss.UUID: (
+                CPCA8Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+            CPCA16Loss.UUID: (
+                CPCA16Loss(subsample_rate=0.2,),  # TODO: test its effects
+                0.05 * aux_loss_total_weight,  # should times 2
+            ),
+        }
+        named_losses = {uuid: total_aux_losses[uuid] for uuid in cls.AUXILIARY_UUIDS}
+        PPOConfig["normalize_advantage"] = cls.normalize_advantage
+        named_losses["ppo_loss"] = (PPO(**PPOConfig), 1.0)
+
+        if cls.multiple_beliefs:  # add weight entropy loss automatically
+            named_losses[TaskWeightsLoss.UUID] = (
+                TaskWeightsLoss(cls.AUXILIARY_UUIDS),
+                0.01,
+            )
+
         return TrainingPipeline(
             save_interval=save_interval,
             metric_accumulate_interval=log_interval,
@@ -39,13 +130,17 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
             update_repeats=update_repeats,
             max_grad_norm=max_grad_norm,
             num_steps=num_steps,
-            named_losses={"ppo_loss": PPO(**PPOConfig)},
+            named_losses={key: val[0] for key, val in named_losses.items()},
             gamma=gamma,
             use_gae=use_gae,
             gae_lambda=gae_lambda,
             advance_scene_rollout_period=cls.ADVANCE_SCENE_ROLLOUT_PERIOD,
             pipeline_stages=[
-                PipelineStage(loss_names=["ppo_loss"], max_stage_steps=ppo_steps)
+                PipelineStage(
+                    loss_names=list(named_losses.keys()),
+                    max_stage_steps=ppo_steps,
+                    loss_weights=[val[1] for val in named_losses.values()],
+                )
             ],
             lr_scheduler_builder=Builder(
                 LambdaLR, {"lr_lambda": LinearDecay(steps=ppo_steps)}

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -52,7 +52,8 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
 
     multiple_beliefs = False
     beliefs_fusion = (  # choose one
-        AttentiveFusion.UUID
+        None
+        # AttentiveFusion.UUID
         # AverageFusion.UUID
         # SoftmaxFusion.UUID
     )

--- a/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
+++ b/projects/pointnav_baselines/experiments/pointnav_thor_mixin_ddppo.py
@@ -58,7 +58,7 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
         # SoftmaxFusion.UUID
     )
 
-    normalize_advantage = False
+    NORMALIZE_ADVANTAGE = False
 
     def training_pipeline(self, **kwargs):
         # PPO
@@ -73,6 +73,7 @@ class PointNavThorMixInPPOConfig(PointNavBaseConfig, ABC):
         use_gae = True
         gae_lambda = 0.95
         max_grad_norm = 0.5
+        PPOConfig["normalize_advantage"] = self.NORMALIZE_ADVANTAGE
 
         named_losses = {"ppo_loss": (PPO(**PPOConfig), 1.0)}
         named_losses = self._update_with_auxiliary_losses(named_losses)

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -38,7 +38,7 @@ class PointNavActorCritic(VisualNavActorCritic):
         coordinate_embedding_dim=8,
         coordinate_dims=2,
         # perception backbone params,
-        backbone="resnet18",
+        backbone="gnresnet18",
         resnet_baseplanes=32,
     ):
         super().__init__(
@@ -71,7 +71,7 @@ class PointNavActorCritic(VisualNavActorCritic):
                 depth_uuid=depth_uuid,
             )
         else:  # resnet family
-            self.visual_encoder = resnet.ResNetEncoder(
+            self.visual_encoder = resnet.GroupNormResNetEncoder(
                 observation_space=observation_space,
                 output_size=hidden_size,
                 rgb_uuid=rgb_uuid,

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -102,7 +102,6 @@ class PointNavActorCritic(VisualNavActorCritic):
         )
 
         self.train()
-        get_logger().info(self)
 
     @property
     def is_blind(self):
@@ -222,7 +221,6 @@ class ResnetTensorPointNavActorCritic(VisualNavActorCritic):
         )
 
         self.train()
-        get_logger().info(self)
 
     @property
     def is_blind(self) -> bool:

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -1,5 +1,4 @@
-from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
-from allenact.utils.system import get_logger
+from typing import Tuple, Dict, Optional, Union, List, cast
 
 import gym
 import torch

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -1,41 +1,56 @@
-from typing import Tuple, Dict, Optional, Union, List, cast
+from typing import Callable, Tuple, Dict, Optional, Union, List, cast, Any
+from allenact.utils.system import get_logger
 
 import gym
 import torch
 import torch.nn as nn
 from gym.spaces.dict import Dict as SpaceDict
 
-from allenact.algorithms.onpolicy_sync.policy import (
-    ActorCriticModel,
-    LinearCriticHead,
-    LinearActorHead,
-    ObservationType,
-    DistributionType,
-)
-from allenact.base_abstractions.distributions import CategoricalDistr
-from allenact.base_abstractions.misc import ActorCriticOutput, Memory
-from allenact.embodiedai.models.basic_models import SimpleCNN, RNNStateEncoder
+from allenact.algorithms.onpolicy_sync.policy import ObservationType
+from allenact.embodiedai.models.basic_models import SimpleCNN
+import allenact.embodiedai.models.resnet as resnet
+from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic
 
 
-class PointNavActorCriticSimpleConvRNN(ActorCriticModel[CategoricalDistr]):
+class PointNavActorCritic(VisualNavActorCritic):
+    """
+    Use raw image as observation to the agent
+    """
+
     def __init__(
+        # base params
         self,
         action_space: gym.spaces.Discrete,
         observation_space: SpaceDict,
-        rgb_uuid: Optional[str],
-        depth_uuid: Optional[str],
         goal_sensor_uuid: str,
         hidden_size=512,
+        num_rnn_layers=1,
+        rnn_type="GRU",
+        add_prev_actions=False,
+        action_embed_size=4,
+        multiple_beliefs=False,
+        beliefs_fusion: Optional[str] = None,
+        auxiliary_uuids: Optional[List[str]] = None,
+        # custom params
+        rgb_uuid: Optional[str] = None,
+        depth_uuid: Optional[str] = None,
         embed_coordinates=False,
         coordinate_embedding_dim=8,
         coordinate_dims=2,
-        num_rnn_layers=1,
-        rnn_type="GRU",
+        # perception backbone params,
+        backbone="resnet18",
+        resnet_baseplanes=32,
     ):
-        super().__init__(action_space=action_space, observation_space=observation_space)
+        super().__init__(
+            action_space=action_space,
+            observation_space=observation_space,
+            hidden_size=hidden_size,
+            multiple_beliefs=multiple_beliefs,
+            beliefs_fusion=beliefs_fusion,
+            auxiliary_uuids=auxiliary_uuids,
+        )
 
         self.goal_sensor_uuid = goal_sensor_uuid
-        self._hidden_size = hidden_size
         self.embed_coordinates = embed_coordinates
         if self.embed_coordinates:
             self.coordinate_embedding_size = coordinate_embedding_dim
@@ -47,42 +62,58 @@ class PointNavActorCriticSimpleConvRNN(ActorCriticModel[CategoricalDistr]):
             self.sensor_fuser = nn.Linear(hidden_size * 2, hidden_size)
             self.sensor_fusion = True
 
-        self.visual_encoder = SimpleCNN(
-            observation_space=observation_space,
-            output_size=hidden_size,
-            rgb_uuid=rgb_uuid,
-            depth_uuid=depth_uuid,
-        )
-
-        self.state_encoder = RNNStateEncoder(
-            (0 if self.is_blind else self.recurrent_hidden_state_size)
-            + self.coordinate_embedding_size,
-            self._hidden_size,
-            num_layers=num_rnn_layers,
-            rnn_type=rnn_type,
-        )
-
-        self.actor = LinearActorHead(self._hidden_size, action_space.n)
-        self.critic = LinearCriticHead(self._hidden_size)
+        self.backbone = backbone
+        if backbone == "simple_cnn":
+            self.visual_encoder = SimpleCNN(
+                observation_space=observation_space,
+                output_size=hidden_size,
+                rgb_uuid=rgb_uuid,
+                depth_uuid=depth_uuid,
+            )
+        else:  # resnet family
+            self.visual_encoder = resnet.ResNetEncoder(
+                observation_space=observation_space,
+                output_size=hidden_size,
+                rgb_uuid=rgb_uuid,
+                depth_uuid=depth_uuid,
+                baseplanes=resnet_baseplanes,
+                ngroups=resnet_baseplanes // 2,
+                make_backbone=getattr(resnet, backbone),
+            )
 
         if self.embed_coordinates:
             self.coordinate_embedding = nn.Linear(
                 coordinate_dims, coordinate_embedding_dim
             )
 
-        self.train()
+        self.create_state_encoders(
+            obs_embed_size=self.goal_visual_encoder_output_dims,
+            num_rnn_layers=num_rnn_layers,
+            rnn_type=rnn_type,
+            add_prev_actions=add_prev_actions,
+            prev_action_embed_size=action_embed_size,
+        )
 
-    @property
-    def output_size(self):
-        return self._hidden_size
+        self.create_actorcritic_head()
+
+        self.create_aux_models(
+            obs_embed_size=self.goal_visual_encoder_output_dims,
+            action_embed_size=action_embed_size,
+        )
+
+        self.train()
+        get_logger().info(self)
 
     @property
     def is_blind(self):
         return self.visual_encoder.is_blind
 
     @property
-    def num_recurrent_layers(self):
-        return self.state_encoder.num_recurrent_layers
+    def goal_visual_encoder_output_dims(self):
+        dims = self.coordinate_embedding_size
+        if self.is_blind:
+            return dims
+        return dims + self.recurrent_hidden_state_size
 
     def get_target_coordinates_encoding(self, observations):
         if self.embed_coordinates:
@@ -92,32 +123,10 @@ class PointNavActorCriticSimpleConvRNN(ActorCriticModel[CategoricalDistr]):
         else:
             return observations[self.goal_sensor_uuid].to(torch.float32)
 
-    @property
-    def recurrent_hidden_state_size(self):
-        return self._hidden_size
-
-    def _recurrent_memory_specification(self):
-        return dict(
-            rnn=(
-                (
-                    ("layer", self.num_recurrent_layers),
-                    ("sampler", None),
-                    ("hidden", self.recurrent_hidden_state_size),
-                ),
-                torch.float32,
-            )
-        )
-
-    def forward(  # type:ignore
-        self,
-        observations: ObservationType,
-        memory: Memory,
-        prev_actions: torch.Tensor,
-        masks: torch.FloatTensor,
-    ) -> Tuple[ActorCriticOutput[DistributionType], Optional[Memory]]:
+    def forward_encoder(self, observations: ObservationType) -> torch.FloatTensor:
         target_encoding = self.get_target_coordinates_encoding(observations)
-        x: Union[torch.Tensor, List[torch.Tensor]]
-        x = [target_encoding]
+        obs_embeds: Union[torch.Tensor, List[torch.Tensor]]
+        obs_embeds = [target_encoding]
 
         # if observations["rgb"].shape[0] != 1:
         #     print("rgb", (observations["rgb"][...,0,0,:].unsqueeze(-2).unsqueeze(-2) == observations["rgb"][...,0,0,:]).float().mean())
@@ -128,37 +137,47 @@ class PointNavActorCriticSimpleConvRNN(ActorCriticModel[CategoricalDistr]):
             perception_embed = self.visual_encoder(observations)
             if self.sensor_fusion:
                 perception_embed = self.sensor_fuser(perception_embed)
-            x = [perception_embed] + x
+            obs_embeds = [perception_embed] + obs_embeds
 
-        x = torch.cat(x, dim=-1)
-        x, rnn_hidden_states = self.state_encoder(x, memory.tensor("rnn"), masks)
-
-        ac_output = ActorCriticOutput(
-            distributions=self.actor(x), values=self.critic(x), extras={}
-        )
-
-        return ac_output, memory.set_tensor("rnn", rnn_hidden_states)
+        obs_embeds = torch.cat(obs_embeds, dim=-1)
+        return obs_embeds
 
 
-class ResnetTensorPointNavActorCritic(ActorCriticModel[CategoricalDistr]):
+class ResnetTensorPointNavActorCritic(VisualNavActorCritic):
+    """
+    Use resnet_preprocessor to generate observations to the agent
+    """
+
     def __init__(
+        # base params
         self,
         action_space: gym.spaces.Discrete,
         observation_space: SpaceDict,
         goal_sensor_uuid: str,
+        hidden_size=512,
+        num_rnn_layers=1,
+        rnn_type="GRU",
+        add_prev_actions=False,
+        action_embed_size=4,
+        multiple_beliefs=False,
+        beliefs_fusion: Optional[str] = None,
+        auxiliary_uuids: Optional[List[str]] = None,
+        # custom params
         rgb_resnet_preprocessor_uuid: Optional[str] = None,
         depth_resnet_preprocessor_uuid: Optional[str] = None,
-        hidden_size: int = 512,
         goal_dims: int = 32,
         resnet_compressor_hidden_out_dims: Tuple[int, int] = (128, 32),
         combiner_hidden_out_dims: Tuple[int, int] = (128, 32),
     ):
-
         super().__init__(
-            action_space=action_space, observation_space=observation_space,
+            action_space=action_space,
+            observation_space=observation_space,
+            hidden_size=hidden_size,
+            multiple_beliefs=multiple_beliefs,
+            beliefs_fusion=beliefs_fusion,
+            auxiliary_uuids=auxiliary_uuids,
         )
 
-        self._hidden_size = hidden_size
         if (
             rgb_resnet_preprocessor_uuid is None
             or depth_resnet_preprocessor_uuid is None
@@ -169,7 +188,7 @@ class ResnetTensorPointNavActorCritic(ActorCriticModel[CategoricalDistr]):
                 else depth_resnet_preprocessor_uuid
             )
             self.goal_visual_encoder = ResnetTensorGoalEncoder(
-                self.observation_space,
+                observation_space,
                 goal_sensor_uuid,
                 resnet_preprocessor_uuid,
                 goal_dims,
@@ -178,7 +197,7 @@ class ResnetTensorPointNavActorCritic(ActorCriticModel[CategoricalDistr]):
             )
         else:
             self.goal_visual_encoder = ResnetDualTensorGoalEncoder(  # type:ignore
-                self.observation_space,
+                observation_space,
                 goal_sensor_uuid,
                 rgb_resnet_preprocessor_uuid,
                 depth_resnet_preprocessor_uuid,
@@ -186,18 +205,24 @@ class ResnetTensorPointNavActorCritic(ActorCriticModel[CategoricalDistr]):
                 resnet_compressor_hidden_out_dims,
                 combiner_hidden_out_dims,
             )
-        self.state_encoder = RNNStateEncoder(
-            self.goal_visual_encoder.output_dims, self._hidden_size,
-        )
-        self.actor = LinearActorHead(self._hidden_size, action_space.n)
-        self.critic = LinearCriticHead(self._hidden_size)
-        self.train()
-        self.memory_key = "rnn"
 
-    @property
-    def recurrent_hidden_state_size(self) -> int:
-        """The recurrent hidden state size of the model."""
-        return self._hidden_size
+        self.create_state_encoders(
+            obs_embed_size=self.goal_visual_encoder.output_dims,
+            num_rnn_layers=num_rnn_layers,
+            rnn_type=rnn_type,
+            add_prev_actions=add_prev_actions,
+            prev_action_embed_size=action_embed_size,
+        )
+
+        self.create_actorcritic_head()
+
+        self.create_aux_models(
+            obs_embed_size=self.goal_visual_encoder.output_dims,
+            action_embed_size=action_embed_size,
+        )
+
+        self.train()
+        get_logger().info(self)
 
     @property
     def is_blind(self) -> bool:
@@ -205,40 +230,8 @@ class ResnetTensorPointNavActorCritic(ActorCriticModel[CategoricalDistr]):
         input observation type)."""
         return self.goal_visual_encoder.is_blind
 
-    @property
-    def num_recurrent_layers(self) -> int:
-        """Number of recurrent hidden layers."""
-        return self.state_encoder.num_recurrent_layers
-
-    def _recurrent_memory_specification(self):
-        return {
-            self.memory_key: (
-                (
-                    ("layer", self.num_recurrent_layers),
-                    ("sampler", None),
-                    ("hidden", self.recurrent_hidden_state_size),
-                ),
-                torch.float32,
-            )
-        }
-
-    def forward(  # type:ignore
-        self,
-        observations: ObservationType,
-        memory: Memory,
-        prev_actions: torch.Tensor,
-        masks: torch.FloatTensor,
-    ) -> Tuple[ActorCriticOutput[DistributionType], Optional[Memory]]:
-        x = self.goal_visual_encoder(observations)
-        x, rnn_hidden_states = self.state_encoder(
-            x, memory.tensor(self.memory_key), masks
-        )
-        return (
-            ActorCriticOutput(
-                distributions=self.actor(x), values=self.critic(x), extras={}
-            ),
-            memory.set_tensor(self.memory_key, rnn_hidden_states),
-        )
+    def forward_encoder(self, observations: ObservationType) -> torch.FloatTensor:
+        return self.goal_visual_encoder(observations)
 
 
 class ResnetTensorGoalEncoder(nn.Module):

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -9,7 +9,10 @@ from gym.spaces.dict import Dict as SpaceDict
 from allenact.algorithms.onpolicy_sync.policy import ObservationType
 from allenact.embodiedai.models.basic_models import SimpleCNN
 import allenact.embodiedai.models.resnet as resnet
-from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic, FusionType
+from allenact.embodiedai.models.visual_nav_models import (
+    VisualNavActorCritic,
+    FusionType,
+)
 
 
 class PointNavActorCritic(VisualNavActorCritic):

--- a/projects/pointnav_baselines/models/point_nav_models.py
+++ b/projects/pointnav_baselines/models/point_nav_models.py
@@ -9,7 +9,7 @@ from gym.spaces.dict import Dict as SpaceDict
 from allenact.algorithms.onpolicy_sync.policy import ObservationType
 from allenact.embodiedai.models.basic_models import SimpleCNN
 import allenact.embodiedai.models.resnet as resnet
-from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic
+from allenact.embodiedai.models.visual_nav_models import VisualNavActorCritic, FusionType
 
 
 class PointNavActorCritic(VisualNavActorCritic):
@@ -29,7 +29,7 @@ class PointNavActorCritic(VisualNavActorCritic):
         add_prev_actions=False,
         action_embed_size=4,
         multiple_beliefs=False,
-        beliefs_fusion: Optional[str] = None,
+        beliefs_fusion: Optional[FusionType] = None,
         auxiliary_uuids: Optional[List[str]] = None,
         # custom params
         rgb_uuid: Optional[str] = None,
@@ -160,7 +160,7 @@ class ResnetTensorPointNavActorCritic(VisualNavActorCritic):
         add_prev_actions=False,
         action_embed_size=4,
         multiple_beliefs=False,
-        beliefs_fusion: Optional[str] = None,
+        beliefs_fusion: Optional[FusionType] = None,
         auxiliary_uuids: Optional[List[str]] = None,
         # custom params
         rgb_resnet_preprocessor_uuid: Optional[str] = None,


### PR DESCRIPTION
This PR includes:
- Provide logging in one folder option and make it as default
- Provide a base class  `VisualNavActorCritic` to be inherited from different downstream navigation model classes (i.e. code refactoring), and also add the modified ResNet18 from https://github.com/joel99/habitat-pointnav-aux
- Introduce self-supervised aux tasks and fusion models based on the code: https://github.com/joel99/habitat-pointnav-aux , including inverse dynamics, temporal distance, and CPC|A.
- Update corresponding experiment config files in pointnav and objectnav

I tested the change by running commands:
```bash
python main.py projects/objectnav_baselines/experiments/robothor/objectnav_robothor_rgb_rawgru_ddppo.py \
    -o experiment_output/objectnav/ --seed 302
python main.py projects/pointnav_baselines/experiments/robothor/pointnav_robothor_rgb_simpleconvgru_ddppo.py\
    -o experiment_output/pointnav/ --seed 302

```
