### PR TITLE
Enabling the computation/logging of losses during testing/validation.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest tests
+        pytest --capture=tee-sys tests
 
     - if: always() # Updates the commit status badge to the result of running the tests above
       uses: ouzi-dev/commit-status-updater@v1.1.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,6 @@ jobs:
         python -m pip install --editable="./allenact_plugins[all]"
         python -m pip install pip install -r allenact_plugins/babyai_plugin/extra_requirements.txt # Required as babyai is not on PyPI
         python -m pip install compress_pickle # Needed for some mapping tests
-        python -m pip install -U protobuf==3.20.1 # Required until tensorboardX is fixed: https://github.com/lanpa/tensorboardX/issues/663
         pip list
 
     - name: Test with pytest

--- a/allenact/algorithms/onpolicy_sync/engine.py
+++ b/allenact/algorithms/onpolicy_sync/engine.py
@@ -1342,6 +1342,10 @@ class OnPolicyTrainer(OnPolicyRLEngine):
     def checkpoint_load(
         self, ckpt: Union[str, Dict[str, Any]], restart_pipeline: bool = False
     ) -> Dict[str, Union[Dict[str, Any], torch.Tensor, float, int, str, List]]:
+        if restart_pipeline:
+            if "training_pipeline_state_dict" in ckpt:
+                del ckpt["training_pipeline_state_dict"]
+
         ckpt = super().checkpoint_load(ckpt)
 
         if restart_pipeline:

--- a/allenact/algorithms/onpolicy_sync/engine.py
+++ b/allenact/algorithms/onpolicy_sync/engine.py
@@ -155,7 +155,7 @@ class OnPolicyRLEngine(object):
             TRAIN_MODE_STR,
             VALID_MODE_STR,
             TEST_MODE_STR,
-        ], 'Only "train", "valid", "test" modes supported'
+        ], f"Only {TRAIN_MODE_STR}, {VALID_MODE_STR}, {TEST_MODE_STR}, modes supported"
 
         self.callback_sensors = callback_sensors
         self.deterministic_cudnn = deterministic_cudnn
@@ -271,11 +271,23 @@ class OnPolicyRLEngine(object):
         )
         self._is_closed: bool = False
 
-        self.training_pipeline: Optional[TrainingPipeline] = None
-
-        # Keeping track of metrics during training/inference
+        # Keeping track of metrics and losses during training/inference
         self.single_process_metrics: List = []
         self.single_process_task_callback_data: List = []
+        self.tracking_info_list: List[TrackingInfo] = []
+
+        # Variables that wil only be instantiated in the trainer
+        self.optimizer: Optional[optim.optimizer.Optimizer] = None
+        # noinspection PyProtectedMember
+        self.lr_scheduler: Optional[_LRScheduler] = None
+        self.insufficient_data_for_update: Optional[
+            torch.distributed.PrefixStore
+        ] = None
+
+        # Training pipeline will be instantiated during training and inference.
+        # During inference however, it will be instantiated anew on each run of `run_eval`
+        # and will be set to `None` after the eval run is complete.
+        self.training_pipeline: Optional[TrainingPipeline] = None
 
     @property
     def vector_tasks(
@@ -343,7 +355,7 @@ class OnPolicyRLEngine(object):
             fn = self.config.test_task_sampler_args
         else:
             raise NotImplementedError(
-                "self.mode must be one of `train`, `valid` or `test`."
+                f"self.mode must be one of {TRAIN_MODE_STR}, {VALID_MODE_STR}, or {TEST_MODE_STR}."
             )
 
         if self.is_distributed:
@@ -388,6 +400,11 @@ class OnPolicyRLEngine(object):
         )
 
         self.actor_critic.load_state_dict(ckpt["model_state_dict"])  # type:ignore
+
+        if "training_pipeline_state_dict" in ckpt:
+            self.training_pipeline.load_state_dict(
+                cast(Dict[str, Any], ckpt["training_pipeline_state_dict"])
+            )
 
         return ckpt
 
@@ -452,14 +469,28 @@ class OnPolicyRLEngine(object):
         storage_to_initialize: Optional[Sequence[ExperienceStorage]],
         visualizer: Optional[VizSuite] = None,
     ):
-        observations = self.vector_tasks.get_observations()
 
-        npaused, keep, batch = self.remove_paused(observations)
-        observations = self._preprocess_observations(batch) if len(keep) > 0 else batch
+        if visualizer is not None or (
+            storage_to_initialize is not None
+            and any(isinstance(s, RolloutStorage) for s in storage_to_initialize)
+        ):
+            # No rollout storage, thus we are not
+            observations = self.vector_tasks.get_observations()
 
-        assert npaused == 0, f"{npaused} samplers are paused during initialization."
+            npaused, keep, batch = self.remove_paused(observations)
+            observations = (
+                self._preprocess_observations(batch) if len(keep) > 0 else batch
+            )
 
-        num_samplers = len(keep)
+            assert npaused == 0, f"{npaused} samplers are paused during initialization."
+
+            num_samplers = len(keep)
+        else:
+            observations = {}
+            num_samplers = 0
+            npaused = 0
+            keep = []
+
         recurrent_memory_specification = (
             self.actor_critic.recurrent_memory_specification
         )
@@ -475,7 +506,7 @@ class OnPolicyRLEngine(object):
                     action_space=self.actor_critic.action_space,
                 )
 
-        if visualizer is not None and len(keep) > 0:
+        if visualizer is not None and num_samplers > 0:
             visualizer.collect(vector_task=self.vector_tasks, alive=keep)
 
         return npaused
@@ -500,6 +531,52 @@ class OnPolicyRLEngine(object):
             actions = distr.sample() if not self.deterministic_agents else distr.mode()
 
         return actions, actor_critic_output, memory, agent_input["observations"]
+
+    def aggregate_and_send_logging_package(
+        self,
+        tracking_info_list: List[TrackingInfo],
+        logging_pkg: Optional[LoggingPackage] = None,
+        send_logging_package: bool = True,
+    ):
+        if logging_pkg is None:
+            logging_pkg = LoggingPackage(
+                mode=self.mode,
+                training_steps=self.training_pipeline.total_steps,
+                pipeline_stage=self.training_pipeline.current_stage_index,
+                storage_uuid_to_total_experiences=self.training_pipeline.storage_uuid_to_total_experiences,
+            )
+
+        self.aggregate_task_metrics(logging_pkg=logging_pkg)
+
+        for callback_dict in self.single_process_task_callback_data:
+            logging_pkg.task_callback_data.append(callback_dict)
+        self.single_process_task_callback_data = []
+
+        for tracking_info in tracking_info_list:
+            if tracking_info.n < 0:
+                get_logger().warning(
+                    f"Obtained a train_info_dict with {tracking_info.n} elements."
+                    f" Full info: ({tracking_info.type}, {tracking_info.info}, {tracking_info.n})."
+                )
+            else:
+                tracking_info_dict = tracking_info.info
+
+                if tracking_info.type == TrackingInfoType.LOSS:
+                    tracking_info_dict = {
+                        f"losses/{k}": v for k, v in tracking_info_dict.items()
+                    }
+
+                logging_pkg.add_info_dict(
+                    info_dict=tracking_info_dict,
+                    n=tracking_info.n,
+                    stage_component_uuid=tracking_info.stage_component_uuid,
+                    storage_uuid=tracking_info.storage_uuid,
+                )
+
+        if send_logging_package:
+            self.results_queue.put(logging_pkg)
+
+        return logging_pkg
 
     @staticmethod
     def _active_memory(memory, keep):
@@ -630,10 +707,6 @@ class OnPolicyRLEngine(object):
         # self.probe(dones, npaused)
 
         if npaused > 0:
-            for s in uuid_to_storage.values():
-                if isinstance(s, RolloutStorage):
-                    s.sampler_select(keep)
-
             if self.mode == TRAIN_MODE_STR:
                 raise NotImplementedError(
                     "When trying to get a new task from a task sampler (using the `.next_task()` method)"
@@ -641,6 +714,10 @@ class OnPolicyRLEngine(object):
                     " (and almost certainly a bug in the implementation of the task sampler or in the "
                     " initialization of the task sampler for training)."
                 )
+
+            for s in uuid_to_storage.values():
+                if isinstance(s, RolloutStorage):
+                    s.sampler_select(keep)
 
         to_add_to_storage = dict(
             observations=self._preprocess_observations(batch)
@@ -671,6 +748,327 @@ class OnPolicyRLEngine(object):
                 visualizer.collect(actor_critic=actor_critic_output)
 
         return npaused
+
+    def distributed_weighted_sum(
+        self,
+        to_share: Union[torch.Tensor, float, int],
+        weight: Union[torch.Tensor, float, int],
+    ):
+        """Weighted sum of scalar across distributed workers."""
+        if self.is_distributed:
+            aggregate = torch.tensor(to_share * weight).to(self.device)
+            dist.all_reduce(aggregate)
+            return aggregate.item()
+        else:
+            if abs(1 - weight) > 1e-5:
+                get_logger().warning(
+                    f"Scaling non-distributed value with weight {weight}"
+                )
+            return torch.tensor(to_share * weight).item()
+
+    def distributed_reduce(
+        self, to_share: Union[torch.Tensor, float, int], op: ReduceOp
+    ):
+        """Weighted sum of scalar across distributed workers."""
+        if self.is_distributed:
+            aggregate = torch.tensor(to_share).to(self.device)
+            dist.all_reduce(aggregate, op=op)
+            return aggregate.item()
+        else:
+            return torch.tensor(to_share).item()
+
+    def backprop_step(
+        self,
+        total_loss: torch.Tensor,
+        max_grad_norm: float,
+        local_to_global_batch_size_ratio: float = 1.0,
+    ):
+        raise NotImplementedError
+
+    def save_error_data(self, batch: Dict[str, Any]):
+        raise NotImplementedError
+
+    @property
+    def step_count(self) -> int:
+        if (
+            self.training_pipeline.current_stage is None
+        ):  # Might occur during testing when all stages are complete
+            return 0
+        return self.training_pipeline.current_stage.steps_taken_in_stage
+
+    def compute_losses_track_them_and_backprop(
+        self,
+        stage: PipelineStage,
+        stage_component: StageComponent,
+        storage: ExperienceStorage,
+        skip_backprop: bool = False,
+    ):
+        training = self.mode == TRAIN_MODE_STR
+
+        assert training or skip_backprop
+
+        if training and self.is_distributed:
+            self.insufficient_data_for_update.set(
+                "insufficient_data_for_update", str(0)
+            )
+            dist.barrier(
+                device_ids=None
+                if self.device == torch.device("cpu")
+                else [self.device.index]
+            )
+
+        training_settings = stage_component.training_settings
+
+        loss_names = stage_component.loss_names
+        losses = [self.training_pipeline.get_loss(ln) for ln in loss_names]
+        loss_weights = [stage.uuid_to_loss_weight[ln] for ln in loss_names]
+        loss_update_repeats_list = training_settings.update_repeats
+        if isinstance(loss_update_repeats_list, numbers.Integral):
+            loss_update_repeats_list = [loss_update_repeats_list] * len(loss_names)
+
+        if skip_backprop and isinstance(storage, MiniBatchStorageMixin):
+            if loss_update_repeats_list != [1] * len(loss_names):
+                loss_update_repeats_list = [1] * len(loss_names)
+                get_logger().warning(
+                    "Does not make sense to do multiple updates when"
+                    " skip_backprop is `True` and you are using a storage of type"
+                    " `MiniBatchStorageMixin`. This is likely a problem caused by"
+                    " using a custom valid/test stage component that is inheriting its"
+                    " TrainingSettings from the TrainingPipeline's TrainingSettings. We will override"
+                    " the requested number of updates repeats (which was"
+                    f" {dict(zip(loss_names, loss_update_repeats_list))}) to be 1 for all losses."
+                )
+
+        enough_data_for_update = True
+        for current_update_repeat_index in range(
+            max(loss_update_repeats_list, default=0)
+        ):
+            if isinstance(storage, MiniBatchStorageMixin):
+                batch_iterator = storage.batched_experience_generator(
+                    num_mini_batch=training_settings.num_mini_batch
+                )
+            elif isinstance(storage, StreamingStorageMixin):
+                assert (
+                    training_settings.num_mini_batch is None
+                    or training_settings.num_mini_batch == 1
+                )
+
+                def single_batch_generator(streaming_storage: StreamingStorageMixin):
+                    try:
+                        yield cast(
+                            StreamingStorageMixin, streaming_storage
+                        ).next_batch()
+                    except EOFError:
+                        if not training:
+                            raise
+
+                        if streaming_storage.empty():
+                            yield None
+                        else:
+                            cast(
+                                StreamingStorageMixin, streaming_storage
+                            ).reset_stream()
+                            stage.stage_component_uuid_to_stream_memory[
+                                stage_component.uuid
+                            ].clear()
+                            yield cast(
+                                StreamingStorageMixin, streaming_storage
+                            ).next_batch()
+
+                batch_iterator = single_batch_generator(streaming_storage=storage)
+            else:
+                raise NotImplementedError(
+                    f"Storage {storage} must be a subclass of `MiniBatchStorageMixin` or `StreamingStorageMixin`."
+                )
+
+            for batch in batch_iterator:
+                if batch is None:
+                    # This should only happen in a `StreamingStorageMixin` when it cannot
+                    # generate an initial batch or when we are in testing/validation and
+                    # we've reached the end of the dataset over which to test/validate.
+                    if training:
+                        assert isinstance(storage, StreamingStorageMixin)
+                        get_logger().warning(
+                            f"Worker {self.worker_id}: could not run update in {storage}, potentially because"
+                            f" not enough data has been accumulated to be able to fill an initial batch."
+                        )
+                    else:
+                        pass
+                    enough_data_for_update = False
+
+                if training and self.is_distributed:
+                    self.insufficient_data_for_update.add(
+                        "insufficient_data_for_update",
+                        1 * (not enough_data_for_update),
+                    )
+                    dist.barrier(
+                        device_ids=None
+                        if self.device == torch.device("cpu")
+                        else [self.device.index]
+                    )
+
+                    if (
+                        int(
+                            self.insufficient_data_for_update.get(
+                                "insufficient_data_for_update"
+                            )
+                        )
+                        != 0
+                    ):
+                        enough_data_for_update = False
+                        break
+
+                info: Dict[str, float] = {}
+
+                bsize: Optional[int] = None
+                total_loss: Optional[torch.Tensor] = None
+                actor_critic_output_for_batch: Optional[ActorCriticOutput] = None
+                batch_memory = Memory()
+
+                for loss, loss_name, loss_weight, max_update_repeats_for_loss in zip(
+                    losses, loss_names, loss_weights, loss_update_repeats_list
+                ):
+                    if current_update_repeat_index >= max_update_repeats_for_loss:
+                        continue
+
+                    if isinstance(loss, AbstractActorCriticLoss):
+                        bsize = batch["bsize"]
+
+                        if actor_critic_output_for_batch is None:
+
+                            try:
+                                actor_critic_output_for_batch, _ = self.actor_critic(
+                                    observations=batch["observations"],
+                                    memory=batch["memory"],
+                                    prev_actions=batch["prev_actions"],
+                                    masks=batch["masks"],
+                                )
+                            except ValueError:
+                                save_path = self.save_error_data(batch=batch)
+                                get_logger().error(
+                                    f"Encountered a value error! Likely because of nans in the output/input."
+                                    f" Saving all error information to {save_path}."
+                                )
+                                raise
+
+                        loss_return = loss.loss(
+                            step_count=self.step_count,
+                            batch=batch,
+                            actor_critic_output=actor_critic_output_for_batch,
+                        )
+
+                        per_epoch_info = {}
+                        if len(loss_return) == 2:
+                            current_loss, current_info = loss_return
+                        elif len(loss_return) == 3:
+                            current_loss, current_info, per_epoch_info = loss_return
+                        else:
+                            raise NotImplementedError
+
+                    elif isinstance(loss, GenericAbstractLoss):
+                        loss_output = loss.loss(
+                            model=self.actor_critic,
+                            batch=batch,
+                            batch_memory=batch_memory,
+                            stream_memory=stage.stage_component_uuid_to_stream_memory[
+                                stage_component.uuid
+                            ],
+                        )
+                        current_loss = loss_output.value
+                        current_info = loss_output.info
+                        per_epoch_info = loss_output.per_epoch_info
+                        batch_memory = loss_output.batch_memory
+                        stage.stage_component_uuid_to_stream_memory[
+                            stage_component.uuid
+                        ] = loss_output.stream_memory
+                        bsize = loss_output.bsize
+                    else:
+                        raise NotImplementedError(
+                            f"Loss of type {type(loss)} is not supported. Losses must be subclasses of"
+                            f" `AbstractActorCriticLoss` or `GenericAbstractLoss`."
+                        )
+
+                    if total_loss is None:
+                        total_loss = loss_weight * current_loss
+                    else:
+                        total_loss = total_loss + loss_weight * current_loss
+
+                    for key, value in current_info.items():
+                        info[f"{loss_name}/{key}"] = value
+
+                    if per_epoch_info is not None:
+                        for key, value in per_epoch_info.items():
+                            if max(loss_update_repeats_list, default=0) > 1:
+                                info[
+                                    f"{loss_name}/{key}_epoch{current_update_repeat_index:02d}"
+                                ] = value
+                                info[f"{loss_name}/{key}_combined"] = value
+                            else:
+                                info[f"{loss_name}/{key}"] = value
+
+                assert total_loss is not None, (
+                    f"No {stage_component.uuid} losses specified for training in stage"
+                    f" {self.training_pipeline.current_stage_index}"
+                )
+
+                total_loss_scalar = total_loss.item()
+                info[f"total_loss"] = total_loss_scalar
+
+                self.tracking_info_list.append(
+                    TrackingInfo(
+                        type=TrackingInfoType.LOSS,
+                        info=info,
+                        n=bsize,
+                        storage_uuid=stage_component.storage_uuid,
+                        stage_component_uuid=stage_component.uuid,
+                    )
+                )
+
+                to_track = {
+                    "rollout_epochs": max(loss_update_repeats_list, default=0),
+                    "worker_batch_size": bsize,
+                }
+
+                aggregate_bsize = None
+                if training:
+                    aggregate_bsize = self.distributed_weighted_sum(bsize, 1)
+                    to_track["global_batch_size"] = aggregate_bsize
+                    to_track["lr"] = self.optimizer.param_groups[0]["lr"]
+
+                if training_settings.num_mini_batch is not None:
+                    to_track[
+                        "rollout_num_mini_batch"
+                    ] = training_settings.num_mini_batch
+
+                for k, v in to_track.items():
+                    # We need to set the bsize to 1 for `worker_batch_size` below as we're trying to record the
+                    # average batch size per worker, not the average per worker weighted by the size of the batches
+                    # of those workers.
+                    self.tracking_info_list.append(
+                        TrackingInfo(
+                            type=TrackingInfoType.UPDATE_INFO,
+                            info={k: v},
+                            n=1 if k == "worker_batch_size" else bsize,
+                            storage_uuid=stage_component.storage_uuid,
+                            stage_component_uuid=stage_component.uuid,
+                        )
+                    )
+
+                if not skip_backprop:
+                    self.backprop_step(
+                        total_loss=total_loss,
+                        max_grad_norm=training_settings.max_grad_norm,
+                        local_to_global_batch_size_ratio=bsize / aggregate_bsize,
+                    )
+
+                stage.stage_component_uuid_to_stream_memory[
+                    stage_component.uuid
+                ] = detach_recursively(
+                    input=stage.stage_component_uuid_to_stream_memory[
+                        stage_component.uuid
+                    ],
+                    inplace=True,
+                )
 
     def close(self, verbose=True):
         self._is_closing = True
@@ -821,7 +1219,6 @@ class OnPolicyTrainer(OnPolicyRLEngine):
             self.offpolicy_epoch_done = None
 
         # Keeping track of training state
-        self.tracking_info_list: List[TrackingInfo] = []
         self.former_steps: Optional[int] = None
         self.last_log: Optional[int] = None
         self.last_save: Optional[int] = None
@@ -889,6 +1286,28 @@ class OnPolicyTrainer(OnPolicyRLEngine):
                 torch.save(save_dict, model_path)
         return model_path
 
+    def aggregate_and_send_logging_package(
+        self,
+        tracking_info_list: List[TrackingInfo],
+        logging_pkg: Optional[LoggingPackage] = None,
+        send_logging_package: bool = True,
+    ):
+        logging_pkg = super().aggregate_and_send_logging_package(
+            tracking_info_list=tracking_info_list,
+            logging_pkg=logging_pkg,
+            send_logging_package=send_logging_package,
+        )
+
+        if self.mode == TRAIN_MODE_STR:
+            # Technically self.mode should always be "train" here (as this is the training engine),
+            # this conditional is defensive
+            self._last_aggregated_train_task_metrics.add_scalars(
+                scalars=logging_pkg.metrics_tracker.means(),
+                n=logging_pkg.metrics_tracker.counts(),
+            )
+
+        return logging_pkg
+
     def checkpoint_save(self, pipeline_stage_index: Optional[int] = None) -> str:
         model_path = os.path.join(
             self.checkpoints_dir,
@@ -922,9 +1341,6 @@ class OnPolicyTrainer(OnPolicyRLEngine):
     ) -> Dict[str, Union[Dict[str, Any], torch.Tensor, float, int, str, List]]:
         ckpt = super().checkpoint_load(ckpt)
 
-        self.training_pipeline.load_state_dict(
-            cast(Dict[str, Any], ckpt["training_pipeline_state_dict"])
-        )
         if restart_pipeline:
             self.training_pipeline.restart_pipeline()
         else:
@@ -942,7 +1358,7 @@ class OnPolicyTrainer(OnPolicyRLEngine):
         return self.training_pipeline.current_stage.steps_taken_in_stage
 
     @step_count.setter
-    def step_count(self, val: int):
+    def step_count(self, val: int) -> None:
         self.training_pipeline.current_stage.steps_taken_in_stage = val
 
     @property
@@ -1015,275 +1431,6 @@ class OnPolicyTrainer(OnPolicyRLEngine):
 
         return {"mean": mean, "std": std}
 
-    def distributed_weighted_sum(
-        self,
-        to_share: Union[torch.Tensor, float, int],
-        weight: Union[torch.Tensor, float, int],
-    ):
-        """Weighted sum of scalar across distributed workers."""
-        if self.is_distributed:
-            aggregate = torch.tensor(to_share * weight).to(self.device)
-            dist.all_reduce(aggregate)
-            return aggregate.item()
-        else:
-            if abs(1 - weight) > 1e-5:
-                get_logger().warning(
-                    f"Scaling non-distributed value with weight {weight}"
-                )
-            return torch.tensor(to_share * weight).item()
-
-    def distributed_reduce(
-        self, to_share: Union[torch.Tensor, float, int], op: ReduceOp
-    ):
-        """Weighted sum of scalar across distributed workers."""
-        if self.is_distributed:
-            aggregate = torch.tensor(to_share).to(self.device)
-            dist.all_reduce(aggregate, op=op)
-            return aggregate.item()
-        else:
-            return torch.tensor(to_share).item()
-
-    def update(
-        self,
-        stage: PipelineStage,
-        stage_component: StageComponent,
-        storage: ExperienceStorage,
-    ):
-        if self.is_distributed:
-            self.insufficient_data_for_update.set(
-                "insufficient_data_for_update", str(0)
-            )
-            dist.barrier(
-                device_ids=None
-                if self.device == torch.device("cpu")
-                else [self.device.index]
-            )
-
-        training_settings = stage_component.training_settings
-
-        loss_names = stage_component.loss_names
-        losses = [self.training_pipeline.get_loss(ln) for ln in loss_names]
-        loss_weights = [stage.uuid_to_loss_weight[ln] for ln in loss_names]
-        loss_update_repeats_list = training_settings.update_repeats
-        if isinstance(loss_update_repeats_list, numbers.Integral):
-            loss_update_repeats_list = [loss_update_repeats_list] * len(loss_names)
-
-        enough_data_for_update = True
-        for current_update_repeat_index in range(
-            max(loss_update_repeats_list, default=0)
-        ):
-            if isinstance(storage, MiniBatchStorageMixin):
-                batch_iterator = storage.batched_experience_generator(
-                    num_mini_batch=training_settings.num_mini_batch
-                )
-            elif isinstance(storage, StreamingStorageMixin):
-                assert (
-                    training_settings.num_mini_batch is None
-                    or training_settings.num_mini_batch == 1
-                )
-
-                def single_batch_generator(streaming_storage: StreamingStorageMixin):
-                    try:
-                        yield cast(
-                            StreamingStorageMixin, streaming_storage
-                        ).next_batch()
-                    except EOFError:
-                        if streaming_storage.empty():
-                            yield None
-                        else:
-                            cast(
-                                StreamingStorageMixin, streaming_storage
-                            ).reset_stream()
-                            stage.stage_component_uuid_to_stream_memory[
-                                stage_component.uuid
-                            ].clear()
-                            yield cast(
-                                StreamingStorageMixin, streaming_storage
-                            ).next_batch()
-
-                batch_iterator = single_batch_generator(streaming_storage=storage)
-            else:
-                raise NotImplementedError(
-                    f"Storage {storage} must be a subclass of `MiniBatchStorageMixin` or `StreamingStorageMixin`."
-                )
-
-            for batch in batch_iterator:
-                if batch is None:
-                    # This should only happen in a `StreamingStorageMixin` when it cannot
-                    # generate an initial batch.
-                    assert isinstance(storage, StreamingStorageMixin)
-                    get_logger().warning(
-                        f"Worker {self.worker_id}: could not run update in {storage}, potentially because"
-                        f" not enough data has been accumulated to be able to fill an initial batch."
-                    )
-                    enough_data_for_update = False
-
-                if self.is_distributed:
-                    self.insufficient_data_for_update.add(
-                        "insufficient_data_for_update",
-                        1 * (not enough_data_for_update),
-                    )
-                    dist.barrier(
-                        device_ids=None
-                        if self.device == torch.device("cpu")
-                        else [self.device.index]
-                    )
-
-                    if (
-                        int(
-                            self.insufficient_data_for_update.get(
-                                "insufficient_data_for_update"
-                            )
-                        )
-                        != 0
-                    ):
-                        enough_data_for_update = False
-                        break
-
-                info: Dict[str, float] = {}
-
-                bsize: Optional[int] = None
-                total_loss: Optional[torch.Tensor] = None
-                actor_critic_output_for_batch: Optional[ActorCriticOutput] = None
-                batch_memory = Memory()
-
-                for loss, loss_name, loss_weight, max_update_repeats_for_loss in zip(
-                    losses, loss_names, loss_weights, loss_update_repeats_list
-                ):
-                    if current_update_repeat_index >= max_update_repeats_for_loss:
-                        continue
-
-                    if isinstance(loss, AbstractActorCriticLoss):
-                        bsize = batch["bsize"]
-
-                        if actor_critic_output_for_batch is None:
-
-                            try:
-                                actor_critic_output_for_batch, _ = self.actor_critic(
-                                    observations=batch["observations"],
-                                    memory=batch["memory"],
-                                    prev_actions=batch["prev_actions"],
-                                    masks=batch["masks"],
-                                )
-                            except ValueError:
-                                save_path = self.save_error_data(batch=batch)
-                                get_logger().error(
-                                    f"Encountered a value error! Likely because of nans in the output/input."
-                                    f" Saving all error information to {save_path}."
-                                )
-                                raise
-
-                        loss_return = loss.loss(
-                            step_count=self.step_count,
-                            batch=batch,
-                            actor_critic_output=actor_critic_output_for_batch,
-                        )
-
-                        per_epoch_info = {}
-                        if len(loss_return) == 2:
-                            current_loss, current_info = loss_return
-                        elif len(loss_return) == 3:
-                            current_loss, current_info, per_epoch_info = loss_return
-                        else:
-                            raise NotImplementedError
-
-                    elif isinstance(loss, GenericAbstractLoss):
-                        loss_output = loss.loss(
-                            model=self.actor_critic,
-                            batch=batch,
-                            batch_memory=batch_memory,
-                            stream_memory=stage.stage_component_uuid_to_stream_memory[
-                                stage_component.uuid
-                            ],
-                        )
-                        current_loss = loss_output.value
-                        current_info = loss_output.info
-                        per_epoch_info = loss_output.per_epoch_info
-                        batch_memory = loss_output.batch_memory
-                        stage.stage_component_uuid_to_stream_memory[
-                            stage_component.uuid
-                        ] = loss_output.stream_memory
-                        bsize = loss_output.bsize
-                    else:
-                        raise NotImplementedError(
-                            f"Loss of type {type(loss)} is not supported. Losses must be subclasses of"
-                            f" `AbstractActorCriticLoss` or `GenericAbstractLoss`."
-                        )
-
-                    if total_loss is None:
-                        total_loss = loss_weight * current_loss
-                    else:
-                        total_loss = total_loss + loss_weight * current_loss
-
-                    for key, value in current_info.items():
-                        info[f"{loss_name}/{key}"] = value
-
-                    if per_epoch_info is not None:
-                        for key, value in per_epoch_info.items():
-                            if max(loss_update_repeats_list, default=0) > 1:
-                                info[
-                                    f"{loss_name}/{key}_epoch{current_update_repeat_index:02d}"
-                                ] = value
-                                info[f"{loss_name}/{key}_combined"] = value
-                            else:
-                                info[f"{loss_name}/{key}"] = value
-
-                assert total_loss is not None, (
-                    f"No {stage_component.uuid} losses specified for training in stage"
-                    f" {self.training_pipeline.current_stage_index}"
-                )
-
-                total_loss_scalar = total_loss.item()
-                info[f"total_loss"] = total_loss_scalar
-
-                self.tracking_info_list.append(
-                    TrackingInfo(
-                        type=TrackingInfoType.LOSS,
-                        info=info,
-                        n=bsize,
-                        storage_uuid=stage_component.storage_uuid,
-                        stage_component_uuid=stage_component.uuid,
-                    )
-                )
-
-                aggregate_bsize = self.distributed_weighted_sum(bsize, 1)
-                to_track = {
-                    "lr": self.optimizer.param_groups[0]["lr"],
-                    "rollout_epochs": max(loss_update_repeats_list, default=0),
-                    "global_batch_size": aggregate_bsize,
-                    "worker_batch_size": bsize,
-                }
-                if training_settings.num_mini_batch is not None:
-                    to_track[
-                        "rollout_num_mini_batch"
-                    ] = training_settings.num_mini_batch
-
-                for k, v in to_track.items():
-                    self.tracking_info_list.append(
-                        TrackingInfo(
-                            type=TrackingInfoType.UPDATE_INFO,
-                            info={k: v},
-                            n=bsize,
-                            storage_uuid=stage_component.storage_uuid,
-                            stage_component_uuid=stage_component.uuid,
-                        )
-                    )
-
-                self.backprop_step(
-                    total_loss=total_loss,
-                    max_grad_norm=training_settings.max_grad_norm,
-                    local_to_global_batch_size_ratio=bsize / aggregate_bsize,
-                )
-
-                stage.stage_component_uuid_to_stream_memory[
-                    stage_component.uuid
-                ] = detach_recursively(
-                    input=stage.stage_component_uuid_to_stream_memory[
-                        stage_component.uuid
-                    ],
-                    inplace=True,
-                )
-
     def backprop_step(
         self,
         total_loss: torch.Tensor,
@@ -1317,53 +1464,6 @@ class OnPolicyTrainer(OnPolicyRLEngine):
 
         self.optimizer.step()  # type: ignore
 
-    def aggregate_and_send_logging_package(
-        self, tracking_info_list: List[TrackingInfo]
-    ):
-        logging_pkg = LoggingPackage(
-            mode=self.mode,
-            training_steps=self.training_pipeline.total_steps,
-            pipeline_stage=self.training_pipeline.current_stage_index,
-            storage_uuid_to_total_experiences=self.training_pipeline.storage_uuid_to_total_experiences,
-        )
-
-        self.aggregate_task_metrics(logging_pkg=logging_pkg)
-
-        for callback_dict in self.single_process_task_callback_data:
-            logging_pkg.task_callback_data.append(callback_dict)
-        self.single_process_task_callback_data = []
-
-        if self.mode == TRAIN_MODE_STR:
-            # Technically self.mode should always be "train" here (as this is the training engine),
-            # this conditional is defensive
-            self._last_aggregated_train_task_metrics.add_scalars(
-                scalars=logging_pkg.metrics_tracker.means(),
-                n=logging_pkg.metrics_tracker.counts(),
-            )
-
-        for tracking_info in tracking_info_list:
-            if tracking_info.n < 0:
-                get_logger().warning(
-                    f"Obtained a train_info_dict with {tracking_info.n} elements."
-                    f" Full info: ({tracking_info.type}, {tracking_info.info}, {tracking_info.n})."
-                )
-            else:
-                tracking_info_dict = tracking_info.info
-
-                if tracking_info.type == TrackingInfoType.LOSS:
-                    tracking_info_dict = {
-                        f"losses/{k}": v for k, v in tracking_info_dict.items()
-                    }
-
-                logging_pkg.add_train_info_dict(
-                    train_info_dict=tracking_info_dict,
-                    n=tracking_info.n,
-                    stage_component_uuid=tracking_info.stage_component_uuid,
-                    storage_uuid=tracking_info.storage_uuid,
-                )
-
-        self.results_queue.put(logging_pkg)
-
     def _save_checkpoint_then_send_checkpoint_for_validation_and_update_last_save_counter(
         self, pipeline_stage_index: Optional[int] = None
     ):
@@ -1382,7 +1482,9 @@ class OnPolicyTrainer(OnPolicyRLEngine):
         rollout_storage = self.training_pipeline.rollout_storage
         uuid_to_storage = self.training_pipeline.current_stage_storage
         self.initialize_storage_and_viz(
-            storage_to_initialize=list(uuid_to_storage.values())
+            storage_to_initialize=cast(
+                List[ExperienceStorage], list(uuid_to_storage.values())
+            )
         )
         self.tracking_info_list.clear()
 
@@ -1486,111 +1588,134 @@ class OnPolicyTrainer(OnPolicyRLEngine):
                 for k, v in self.training_pipeline.current_stage_storage.items()
             }
 
-            vector_tasks_already_restarted = False
-            step = -1
-            while step < cur_stage_training_settings.num_steps - 1:
-                step += 1
+            if self.training_pipeline.rollout_storage_uuid is None:
+                # In this case we're not expecting to collect storage experiences, i.e. everything
+                # will be off-policy.
 
-                try:
-                    num_paused = self.collect_step_across_all_task_samplers(
-                        rollout_storage_uuid=self.training_pipeline.rollout_storage_uuid,
-                        uuid_to_storage=uuid_to_storage,
+                # self.step_count is normally updated by the `self.collect_step_across_all_task_samplers`
+                # call below, but since we're not collecting onpolicy experiences, we need to update
+                # it here. The step count here is now just effectively a count of the number of times
+                # we've called `compute_losses_track_them_and_backprop` below.
+                self.step_count += 1
+
+                before_update_info = dict(
+                    next_value=None,
+                    use_gae=cur_stage_training_settings.use_gae,
+                    gamma=cur_stage_training_settings.gamma,
+                    tau=cur_stage_training_settings.gae_lambda,
+                    adv_stats_callback=self.advantage_stats,
+                )
+            else:
+                vector_tasks_already_restarted = False
+                step = -1
+                while step < cur_stage_training_settings.num_steps - 1:
+                    step += 1
+
+                    try:
+                        num_paused = self.collect_step_across_all_task_samplers(
+                            rollout_storage_uuid=self.training_pipeline.rollout_storage_uuid,
+                            uuid_to_storage=uuid_to_storage,
+                        )
+                    except (TimeoutError, EOFError) as e:
+                        if (
+                            not self.try_restart_after_task_error
+                        ) or self.mode != TRAIN_MODE_STR:
+                            # Apparently you can just call `raise` here and doing so will just raise the exception as though
+                            # it was not caught (so the stacktrace isn't messed up)
+                            raise
+                        elif vector_tasks_already_restarted:
+                            raise RuntimeError(
+                                f"[{self.mode} worker {self.worker_id}] `vector_tasks` has timed out twice in the same"
+                                f" rollout. This suggests that this error was not recoverable. Timeout exception:\n{traceback.format_exc()}"
+                            )
+                        else:
+                            get_logger().warning(
+                                f"[{self.mode} worker {self.worker_id}] `vector_tasks` appears to have crashed during"
+                                f" training due to an {type(e).__name__} error. You have set"
+                                f" `try_restart_after_task_error` to `True` so we will attempt to restart these tasks from"
+                                f" the beginning. USE THIS FEATURE AT YOUR OWN"
+                                f" RISK. Exception:\n{traceback.format_exc()}."
+                            )
+                            self.vector_tasks.close()
+                            self._vector_tasks = None
+
+                            vector_tasks_already_restarted = True
+                            for (
+                                storage
+                            ) in self.training_pipeline.current_stage_storage.values():
+                                storage.after_updates()
+                            self.initialize_storage_and_viz(
+                                storage_to_initialize=cast(
+                                    List[ExperienceStorage],
+                                    list(uuid_to_storage.values()),
+                                )
+                            )
+                            step = -1
+                            continue
+
+                    # A more informative error message should already have been thrown in be given in
+                    # `collect_step_across_all_task_samplers` if `num_paused != 0` here but this serves
+                    # as a sanity check.
+                    assert num_paused == 0
+
+                    if self.is_distributed:
+                        # Preempt stragglers
+                        # Each worker will stop collecting steps for the current rollout whenever a
+                        # 100 * distributed_preemption_threshold percentage of workers are finished collecting their
+                        # rollout steps, and we have collected at least 25% but less than 90% of the steps.
+                        num_done = int(self.num_workers_done.get("done"))
+                        if (
+                            num_done
+                            > self.distributed_preemption_threshold * self.num_workers
+                            and 0.25 * cur_stage_training_settings.num_steps
+                            <= step
+                            < 0.9 * cur_stage_training_settings.num_steps
+                        ):
+                            get_logger().debug(
+                                f"[{self.mode} worker {self.worker_id}] Preempted after {step}"
+                                f" steps (out of {cur_stage_training_settings.num_steps})"
+                                f" with {num_done} workers done"
+                            )
+                            break
+
+                with torch.no_grad():
+                    actor_critic_output, _ = self.actor_critic(
+                        **rollout_storage.agent_input_for_next_step()
                     )
-                except (TimeoutError, EOFError) as e:
-                    if (
-                        not self.try_restart_after_task_error
-                    ) or self.mode != TRAIN_MODE_STR:
-                        # Apparently you can just call `raise` here and doing so will just raise the exception as though
-                        # it was not caught (so the stacktrace isn't messed up)
-                        raise
-                    elif vector_tasks_already_restarted:
-                        raise RuntimeError(
-                            f"[{self.mode} worker {self.worker_id}] `vector_tasks` has timed out twice in the same"
-                            f" rollout. This suggests that this error was not recoverable. Timeout exception:\n{traceback.format_exc()}"
-                        )
-                    else:
-                        get_logger().warning(
-                            f"[{self.mode} worker {self.worker_id}] `vector_tasks` appears to have crashed during"
-                            f" training due to an {type(e).__name__} error. You have set"
-                            f" `try_restart_after_task_error` to `True` so we will attempt to restart these tasks from"
-                            f" the beginning. USE THIS FEATURE AT YOUR OWN"
-                            f" RISK. Exception:\n{traceback.format_exc()}."
-                        )
-                        self.vector_tasks.close()
-                        self._vector_tasks = None
 
-                        vector_tasks_already_restarted = True
-                        for (
-                            storage
-                        ) in self.training_pipeline.current_stage_storage.values():
-                            storage.after_updates()
-                        self.initialize_storage_and_viz(
-                            storage_to_initialize=list(uuid_to_storage.values())
-                        )
-                        step = -1
-                        continue
-
-                # A more informative error message should already have been thrown in be given in
-                # `collect_step_across_all_task_samplers` if `num_paused != 0` here but this serves
-                # as a sanity check.
-                assert num_paused == 0
+                self.training_pipeline.rollout_count += 1
 
                 if self.is_distributed:
-                    # Preempt stragglers
-                    # Each worker will stop collecting steps for the current rollout whenever a
-                    # 100 * distributed_preemption_threshold percentage of workers are finished collecting their
-                    # rollout steps, and we have collected at least 25% but less than 90% of the steps.
-                    num_done = int(self.num_workers_done.get("done"))
-                    if (
-                        num_done
-                        > self.distributed_preemption_threshold * self.num_workers
-                        and 0.25 * cur_stage_training_settings.num_steps
-                        <= step
-                        < 0.9 * cur_stage_training_settings.num_steps
-                    ):
-                        get_logger().debug(
-                            f"[{self.mode} worker {self.worker_id}] Preempted after {step}"
-                            f" steps (out of {cur_stage_training_settings.num_steps})"
-                            f" with {num_done} workers done"
-                        )
-                        break
+                    # Mark that a worker is done collecting experience
+                    self.num_workers_done.add("done", 1)
+                    self.num_workers_steps.add(
+                        "steps", self.step_count - self.former_steps
+                    )
 
-            with torch.no_grad():
-                actor_critic_output, _ = self.actor_critic(
-                    **rollout_storage.agent_input_for_next_step()
+                    # Ensure all workers are done before updating step counter
+                    dist.barrier(
+                        device_ids=None
+                        if self.device == torch.device("cpu")
+                        else [self.device.index]
+                    )
+
+                    ndone = int(self.num_workers_done.get("done"))
+                    assert (
+                        ndone == self.num_workers
+                    ), f"# workers done {ndone} != # workers {self.num_workers}"
+
+                    # get the actual step_count
+                    self.step_count = (
+                        int(self.num_workers_steps.get("steps")) + self.former_steps
+                    )
+
+                before_update_info = dict(
+                    next_value=actor_critic_output.values.detach(),
+                    use_gae=cur_stage_training_settings.use_gae,
+                    gamma=cur_stage_training_settings.gamma,
+                    tau=cur_stage_training_settings.gae_lambda,
+                    adv_stats_callback=self.advantage_stats,
                 )
-
-            self.training_pipeline.rollout_count += 1
-
-            if self.is_distributed:
-                # Mark that a worker is done collecting experience
-                self.num_workers_done.add("done", 1)
-                self.num_workers_steps.add("steps", self.step_count - self.former_steps)
-
-                # Ensure all workers are done before updating step counter
-                dist.barrier(
-                    device_ids=None
-                    if self.device == torch.device("cpu")
-                    else [self.device.index]
-                )
-
-                ndone = int(self.num_workers_done.get("done"))
-                assert (
-                    ndone == self.num_workers
-                ), f"# workers done {ndone} != # workers {self.num_workers}"
-
-                # get the actual step_count
-                self.step_count = (
-                    int(self.num_workers_steps.get("steps")) + self.former_steps
-                )
-
-            before_update_info = dict(
-                next_value=actor_critic_output.values.detach(),
-                use_gae=cur_stage_training_settings.use_gae,
-                gamma=cur_stage_training_settings.gamma,
-                tau=cur_stage_training_settings.gae_lambda,
-                adv_stats_callback=self.advantage_stats,
-            )
 
             # Prepare storage for iteration during updates
             for storage in self.training_pipeline.current_stage_storage.values():
@@ -1601,7 +1726,7 @@ class OnPolicyTrainer(OnPolicyRLEngine):
 
                 # before_update = time.time()
 
-                self.update(
+                self.compute_losses_track_them_and_backprop(
                     stage=self.training_pipeline.current_stage,
                     stage_component=sc,
                     storage=component_storage,
@@ -1636,6 +1761,7 @@ class OnPolicyTrainer(OnPolicyRLEngine):
                 change_in_storage_experiences[k] = self.distributed_weighted_sum(
                     to_share=delta, weight=1
                 )
+
             # Then we update `self.training_pipeline.current_stage.storage_uuid_to_steps_taken_in_stage` with the above
             # computed changes.
             for storage_uuid, delta in change_in_storage_experiences.items():
@@ -1678,7 +1804,9 @@ class OnPolicyTrainer(OnPolicyRLEngine):
                 )
                 self.vector_tasks.next_task(force_advance_scene=True)
                 self.initialize_storage_and_viz(
-                    storage_to_initialize=list(uuid_to_storage.values())
+                    storage_to_initialize=cast(
+                        List[ExperienceStorage], list(uuid_to_storage.values())
+                    )
                 )
 
     def train(
@@ -1714,7 +1842,7 @@ class OnPolicyTrainer(OnPolicyRLEngine):
                 if self.worker_id == 0:
                     self.results_queue.put(("train_stopped", 0))
                 get_logger().info(
-                    f"[{self.mode} worker {self.worker_id}]. Training finished successfully."
+                    f"[{self.mode} worker {self.worker_id}] Training finished successfully."
                 )
             else:
                 self.results_queue.put(("train_stopped", 1 + self.worker_id))
@@ -1768,32 +1896,79 @@ class OnPolicyInference(OnPolicyRLEngine):
         update_secs: float = 20.0,
         verbose: bool = False,
     ) -> LoggingPackage:
-        assert self.actor_critic is not None, "called run_eval with no actor_critic"
+        assert self.actor_critic is not None, "called `run_eval` with no actor_critic"
+
+        # Sanity check that we haven't entered an invalid state. During eval the training_pipeline
+        # should be only set in this function and always unset at the end of it.
+        assert (
+            self.training_pipeline is None
+        ), (
+            "`training_pipeline` should be `None` before calling `run_eval`."
+            " This is necessary as we want to initialize new storages."
+        )
+        self.training_pipeline = self.config.training_pipeline()
 
         ckpt = self.checkpoint_load(checkpoint_file_path)
         total_steps = cast(int, ckpt["total_steps"])
 
-        training_pipeline = self.config.training_pipeline()
-        rollout_storage = training_pipeline.rollout_storage
+        eval_pipeline_stage = cast(
+            PipelineStage,
+            getattr(self.training_pipeline, f"{self.mode}_pipeline_stage"),
+        )
+        assert (
+            len(eval_pipeline_stage.stage_components) <= 1
+        ), "Only one StageComponent is supported during inference."
+        uuid_to_storage = self.training_pipeline.get_stage_storage(eval_pipeline_stage)
+
+        assert len(uuid_to_storage) > 0, (
+            "No storage found for eval pipeline stage, this is a bug in AllenAct,"
+            " please submit an issue on GitHub (https://github.com/allenai/allenact/issues)."
+        )
+
+        uuid_to_rollout_storage = {
+            uuid: storage
+            for uuid, storage in uuid_to_storage.items()
+            if isinstance(storage, RolloutStorage)
+        }
+        uuid_to_non_rollout_storage = {
+            uuid: storage
+            for uuid, storage in uuid_to_storage.items()
+            if not isinstance(storage, RolloutStorage)
+        }
+
+        if len(uuid_to_rollout_storage) > 1 or len(uuid_to_non_rollout_storage) > 1:
+            raise NotImplementedError(
+                "Only one RolloutStorage and non-RolloutStorage object is allowed within an evaluation pipeline stage."
+                " If you'd like to evaluate against multiple storages please"
+                " submit an issue on GitHub (https://github.com/allenai/allenact/issues). For the moment you'll need"
+                " to evaluate against these storages separately."
+            )
+
+        rollout_storage = self.training_pipeline.rollout_storage
 
         if visualizer is not None:
             assert visualizer.empty()
 
         num_paused = self.initialize_storage_and_viz(
-            storage_to_initialize=[rollout_storage], visualizer=visualizer,
+            storage_to_initialize=cast(
+                List[ExperienceStorage], list(uuid_to_storage.values())
+            ),
+            visualizer=visualizer,
         )
         assert num_paused == 0, f"{num_paused} tasks paused when initializing eval"
 
-        num_tasks = sum(
-            self.vector_tasks.command(
-                "sampler_attr", ["length"] * self.num_active_samplers
+        if rollout_storage is not None:
+            num_tasks = sum(
+                self.vector_tasks.command(
+                    "sampler_attr", ["length"] * self.num_active_samplers
+                )
+            ) + (  # We need to add this as the first tasks have already been sampled
+                self.num_active_samplers
             )
-        ) + (  # We need to add this as the first tasks have already been sampled
-            self.num_active_samplers
-        )
-        # get_logger().debug(
-        #     "worker {} number of tasks {}".format(self.worker_id, num_tasks)
-        # )
+        else:
+            num_tasks = 0
+
+        # get_logger().debug("worker {self.worker_id} number of tasks {num_tasks}")
         steps = 0
 
         self.actor_critic.eval()
@@ -1823,26 +1998,79 @@ class OnPolicyInference(OnPolicyRLEngine):
         logging_pkg = LoggingPackage(
             mode=self.mode,
             training_steps=total_steps,
-            storage_uuid_to_total_experiences={},
+            storage_uuid_to_total_experiences=self.training_pipeline.storage_uuid_to_total_experiences,
+        )
+        should_compute_onpolicy_losses = (
+            len(eval_pipeline_stage.loss_names) > 0
+            and eval_pipeline_stage.stage_components[0].storage_uuid
+            == self.training_pipeline.rollout_storage_uuid
         )
         while self.num_active_samplers > 0:
             frames += self.num_active_samplers
-            self.collect_step_across_all_task_samplers(
-                rollout_storage_uuid=training_pipeline.rollout_storage_uuid,
-                uuid_to_storage={
-                    training_pipeline.rollout_storage_uuid: rollout_storage
-                },
+            num_newly_paused = self.collect_step_across_all_task_samplers(
+                rollout_storage_uuid=self.training_pipeline.rollout_storage_uuid,
+                uuid_to_storage=uuid_to_rollout_storage,
                 visualizer=visualizer,
                 dist_wrapper_class=dist_wrapper_class,
             )
             steps += 1
 
-            if steps % rollout_steps == 0:
-                rollout_storage.after_updates()
+            if should_compute_onpolicy_losses and num_newly_paused > 0:
+                # The `collect_step_across_all_task_samplers` method will automatically drop
+                # parts of the rollout storage that correspond to paused tasks (namely by calling"
+                # `rollout_storage.sampler_select(UNPAUSED_TASK_INDS)`). This makes sense when you don't need to
+                # compute losses for tasks but is a bit limiting here as we're throwing away data before
+                # using it to compute losses. As changing this is non-trivial we'll just warn the user
+                # for now.
+                get_logger().warning(
+                    f"[{self.mode} worker {self.worker_id}] {num_newly_paused * rollout_storage.step} steps"
+                    f" will be dropped when computing losses in evaluation. This is a limitation of the current"
+                    f" implementation of rollout collection in AllenAct. If you'd like to see this"
+                    f" functionality improved please submit an issue on GitHub"
+                    f" (https://github.com/allenai/allenact/issues)."
+                )
+
+            if self.num_active_samplers == 0 or steps % rollout_steps == 0:
+                if should_compute_onpolicy_losses and self.num_active_samplers > 0:
+                    with torch.no_grad():
+                        actor_critic_output, _ = self.actor_critic(
+                            **rollout_storage.agent_input_for_next_step()
+                        )
+                        before_update_info = dict(
+                            next_value=actor_critic_output.values.detach(),
+                            use_gae=eval_pipeline_stage.training_settings.use_gae,
+                            gamma=eval_pipeline_stage.training_settings.gamma,
+                            tau=eval_pipeline_stage.training_settings.gae_lambda,
+                            adv_stats_callback=lambda advantages: {
+                                "mean": advantages.mean(),
+                                "std": advantages.std(),
+                            },
+                        )
+                    # Prepare storage for iteration during loss computation
+                    for storage in uuid_to_rollout_storage.values():
+                        storage.before_updates(**before_update_info)
+
+                    # Compute losses
+                    with torch.no_grad():
+                        for sc in eval_pipeline_stage.stage_components:
+                            self.compute_losses_track_them_and_backprop(
+                                stage=eval_pipeline_stage,
+                                stage_component=sc,
+                                storage=uuid_to_rollout_storage[sc.storage_uuid],
+                                skip_backprop=True,
+                            )
+
+                for storage in uuid_to_rollout_storage.values():
+                    storage.after_updates()
 
             cur_time = time.time()
             if self.num_active_samplers == 0 or cur_time - last_time >= update_secs:
-                self.aggregate_task_metrics(logging_pkg=logging_pkg)
+                logging_pkg = self.aggregate_and_send_logging_package(
+                    tracking_info_list=self.tracking_info_list,
+                    logging_pkg=logging_pkg,
+                    send_logging_package=False,
+                )
+                self.tracking_info_list.clear()
 
                 if verbose:
                     npending: int
@@ -1883,6 +2111,11 @@ class OnPolicyInference(OnPolicyRLEngine):
                                         f"{k} {v:.3g}"
                                         for k, v in logging_pkg.metrics_tracker.means().items()
                                     ],
+                                    *[
+                                        f"{k0[1]}/{k1} {v1:.3g}"
+                                        for k0, v0 in logging_pkg.info_trackers.items()
+                                        for k1, v1 in v0.means().items()
+                                    ],
                                 ]
                             )
                         )
@@ -1890,22 +2123,112 @@ class OnPolicyInference(OnPolicyRLEngine):
                     last_time = cur_time
 
         get_logger().info(
-            f"[{self.mode} worker {self.worker_id}] Evaluation complete, all task samplers paused."
+            f"[{self.mode} worker {self.worker_id}] Task evaluation complete, all task samplers paused."
         )
 
-        self.vector_tasks.resume_all()
-        self.vector_tasks.set_seeds(self.worker_seeds(self.num_samplers, self.seed))
-        self.vector_tasks.reset_all()
+        if rollout_storage is not None:
+            self.vector_tasks.resume_all()
+            self.vector_tasks.set_seeds(self.worker_seeds(self.num_samplers, self.seed))
+            self.vector_tasks.reset_all()
 
-        self.aggregate_task_metrics(logging_pkg=logging_pkg)
-
-        for callback_dict in self.single_process_task_callback_data:
-            logging_pkg.task_callback_data.append(callback_dict)
-        self.single_process_task_callback_data = []
+        logging_pkg = self.aggregate_and_send_logging_package(
+            tracking_info_list=self.tracking_info_list,
+            logging_pkg=logging_pkg,
+            send_logging_package=False,
+        )
+        self.tracking_info_list.clear()
 
         logging_pkg.viz_data = (
             visualizer.read_and_reset() if visualizer is not None else None
         )
+
+        should_compute_offpolicy_losses = (
+            len(eval_pipeline_stage.loss_names) > 0
+            and not should_compute_onpolicy_losses
+        )
+        if should_compute_offpolicy_losses:
+            # In this case we are evaluating a non-rollout storage, e.g. some off-policy data
+            get_logger().info(
+                f"[{self.mode} worker {self.worker_id}] Non-rollout storage detected, will now compute losses"
+                f" using this storage."
+            )
+
+            offpolicy_eval_done = False
+            while not offpolicy_eval_done:
+                before_update_info = dict(
+                    next_value=None,
+                    use_gae=eval_pipeline_stage.training_settings.use_gae,
+                    gamma=eval_pipeline_stage.training_settings.gamma,
+                    tau=eval_pipeline_stage.training_settings.gae_lambda,
+                    adv_stats_callback=lambda advantages: {
+                        "mean": advantages.mean(),
+                        "std": advantages.std(),
+                    },
+                )
+                # Prepare storage for iteration during loss computation
+                for storage in uuid_to_non_rollout_storage.values():
+                    storage.before_updates(**before_update_info)
+
+                # Compute losses
+                assert len(eval_pipeline_stage.stage_components) == 1
+                try:
+                    for sc in eval_pipeline_stage.stage_components:
+                        with torch.no_grad():
+                            self.compute_losses_track_them_and_backprop(
+                                stage=eval_pipeline_stage,
+                                stage_component=sc,
+                                storage=uuid_to_non_rollout_storage[sc.storage_uuid],
+                                skip_backprop=True,
+                            )
+                except EOFError:
+                    offpolicy_eval_done = True
+
+                for storage in uuid_to_non_rollout_storage.values():
+                    storage.after_updates()
+
+                total_bsize = sum(
+                    tif.info.get("worker_batch_size", 0)
+                    for tif in self.tracking_info_list
+                )
+                logging_pkg = self.aggregate_and_send_logging_package(
+                    tracking_info_list=self.tracking_info_list,
+                    logging_pkg=logging_pkg,
+                    send_logging_package=False,
+                )
+                self.tracking_info_list.clear()
+
+                cur_time = time.time()
+                if verbose and (cur_time - last_time >= update_secs):
+                    get_logger().info(
+                        f"[{self.mode} worker {self.worker_id}]"
+                        f" For ckpt {checkpoint_file_path}"
+                        f" {total_bsize / (cur_time - init_time):.1f} its/sec."
+                    )
+                    if logging_pkg.info_trackers != 0:
+                        get_logger().info(
+                            ", ".join(
+                                [
+                                    f"[{self.mode} worker {self.worker_id}]"
+                                    f" num_{self.mode}_iters_complete {total_bsize}",
+                                    *[
+                                        f"{'/'.join(k0)}/{k1} {v1:.3g}"
+                                        for k0, v0 in logging_pkg.info_trackers.items()
+                                        for k1, v1 in v0.means().items()
+                                    ],
+                                ]
+                            )
+                        )
+
+                    last_time = cur_time
+
+        # Call after_updates here to reset all storages
+        for storage in uuid_to_storage.values():
+            storage.after_updates()
+
+        # Set the training pipeline to `None` so that the storages do not
+        # persist across calls to `run_eval`
+        self.training_pipeline = None
+
         logging_pkg.checkpoint_file_name = checkpoint_file_path
 
         return logging_pkg

--- a/allenact/algorithms/onpolicy_sync/engine.py
+++ b/allenact/algorithms/onpolicy_sync/engine.py
@@ -470,6 +470,7 @@ class OnPolicyRLEngine(object):
         visualizer: Optional[VizSuite] = None,
     ):
 
+        keep: Optional[List] = None
         if visualizer is not None or (
             storage_to_initialize is not None
             and any(isinstance(s, RolloutStorage) for s in storage_to_initialize)
@@ -489,7 +490,6 @@ class OnPolicyRLEngine(object):
             observations = {}
             num_samplers = 0
             npaused = 0
-            keep = []
 
         recurrent_memory_specification = (
             self.actor_critic.recurrent_memory_specification

--- a/allenact/algorithms/onpolicy_sync/runner.py
+++ b/allenact/algorithms/onpolicy_sync/runner.py
@@ -158,6 +158,7 @@ class OnPolicyRunner(object):
 
     @property
     def running_validation(self):
+        pipeline = self.config.training_pipeline()
         return (
             sum(
                 MachineParams.instance_from(
@@ -165,6 +166,10 @@ class OnPolicyRunner(object):
                 ).nprocesses
             )
             > 0
+            or (
+                pipeline.rollout_storage_uuid is None
+                and len(pipeline.valid_pipeline_stage.loss_names) > 0
+            )
         ) and self.machine_id == 0
 
     @staticmethod

--- a/allenact/base_abstractions/callbacks.py
+++ b/allenact/base_abstractions/callbacks.py
@@ -21,32 +21,35 @@ class Callback:
 
     def on_train_log(
         self,
+        *,
         metrics: List[Dict[str, Any]],
         metric_means: Dict[str, float],
-        step: int,
         tasks_data: List[Any],
+        step: int,
         **kwargs,
     ) -> None:
         """Called once train is supposed to log."""
 
     def on_valid_log(
         self,
+        *,
         metrics: Dict[str, Any],
         metric_means: Dict[str, float],
-        checkpoint_file_name: str,
         tasks_data: List[Any],
         step: int,
+        checkpoint_file_name: str,
         **kwargs,
     ) -> None:
         """Called after validation ends."""
 
     def on_test_log(
         self,
-        checkpoint_file_name: str,
+        *,
         metrics: Dict[str, Any],
         metric_means: Dict[str, float],
         tasks_data: List[Any],
         step: int,
+        checkpoint_file_name: str,
         **kwargs,
     ) -> None:
         """Called after test ends."""

--- a/allenact/embodiedai/aux_losses/losses.py
+++ b/allenact/embodiedai/aux_losses/losses.py
@@ -314,7 +314,7 @@ class TemporalDistanceLoss(AuxiliaryLoss):
             np.repeat(locs[:, [1]], 2 * self.num_pairs, axis=-1),  # (M, 2*k)
             np.repeat(locs[:, [2]] + 1, 2 * self.num_pairs, axis=-1),  # (M, 2*k)
         ).reshape(
-            -1, self.num_pairs, 2
+            (-1, self.num_pairs, 2)
         )  # (M, k, 2)
         sampled_pairs_batch = torch.from_numpy(sampled_pairs).to(
             locs_batch

--- a/allenact/utils/experiment_utils.py
+++ b/allenact/utils/experiment_utils.py
@@ -254,7 +254,7 @@ class LoggingPackage:
         self.pipeline_stage = pipeline_stage
 
         self.metrics_tracker = ScalarMeanTracker()
-        self.train_info_trackers: Dict[Tuple[str, str], ScalarMeanTracker] = {}
+        self.info_trackers: Dict[Tuple[str, str], ScalarMeanTracker] = {}
 
         self.metric_dicts: List[Any] = []
         self.viz_data: Optional[Dict[str, List[Dict[str, Any]]]] = None
@@ -296,19 +296,19 @@ class LoggingPackage:
         )
         return True
 
-    def add_train_info_dict(
+    def add_info_dict(
         self,
-        train_info_dict: Dict[str, Union[int, float]],
+        info_dict: Dict[str, Union[int, float]],
         n: int,
         stage_component_uuid: str,
         storage_uuid: str,
     ):
         key = (stage_component_uuid, storage_uuid)
-        if key not in self.train_info_trackers:
-            self.train_info_trackers[key] = ScalarMeanTracker()
+        if key not in self.info_trackers:
+            self.info_trackers[key] = ScalarMeanTracker()
 
         assert n >= 0
-        self.train_info_trackers[key].add_scalars(scalars=train_info_dict, n=n)
+        self.info_trackers[key].add_scalars(scalars=info_dict, n=n)
 
 
 class LinearDecay(object):
@@ -559,8 +559,8 @@ class TrainingSettings:
 
 @attr.s(kw_only=True)
 class StageComponent:
-    """An custom component for a PipelineStage, possibly including overrides to
-    the `TrainingSettings` in from the `TrainingPipeline` and `PipelineStage`.
+    """A custom component for a PipelineStage, possibly including overrides to
+    the `TrainingSettings` from the `TrainingPipeline` and `PipelineStage`.
 
     # Attributes
 
@@ -619,7 +619,7 @@ class PipelineStage:
         occurs. If `early_stopping_criterion` is not `None` then we do not guarantee
         reproducibility when restarting a model from a checkpoint (as the
         `EarlyStoppingCriterion` object may store internal state which is not
-        saved in the checkpoint). Currently AllenAct only supports using early stopping
+        saved in the checkpoint). Currently, AllenAct only supports using early stopping
         criterion when **not** using distributed training.
     training_settings: Instance of `TrainingSettings`.
     training_settings_kwargs: For backwards compatability: arguments to instantiate TrainingSettings when
@@ -798,6 +798,8 @@ class TrainingPipeline:
         should_log: bool = True,
         lr_scheduler_builder: Optional[Builder[_LRScheduler]] = None,  # type: ignore
         training_settings: Optional[TrainingSettings] = None,
+        valid_pipeline_stage: Optional[PipelineStage] = None,
+        test_pipeline_stage: Optional[PipelineStage] = None,
         **training_settings_kwargs,
     ):
         """Initializer.
@@ -831,11 +833,31 @@ class TrainingPipeline:
             rollout_storage_uuid
         )
 
+        if self.rollout_storage_uuid is None:
+            get_logger().info(
+                f"No rollout storage was specified in the TrainingPipeline. This need not be an issue"
+                f" if you are performing off-policy training but, otherwise, please ensure you have"
+                f" defined a rollout storage in the `named_storages` argument of the TrainingPipeline."
+            )
+
         self.should_log = should_log
 
         self.pipeline_stages = pipeline_stages
-        assert len(self.pipeline_stages) == len(
-            set(id(ps) for ps in pipeline_stages)
+
+        def if_none_then_empty_stage(stage: Optional[PipelineStage]) -> PipelineStage:
+            return (
+                stage
+                if stage is not None
+                else PipelineStage(max_stage_steps=-1, loss_names=[])
+            )
+
+        self.valid_pipeline_stage = if_none_then_empty_stage(valid_pipeline_stage)
+        self.test_pipeline_stage = if_none_then_empty_stage(test_pipeline_stage)
+
+        assert (
+            len(self.pipeline_stages) == len(set(id(ps) for ps in pipeline_stages))
+            and self.valid_pipeline_stage not in self.pipeline_stages
+            and self.test_pipeline_stage not in self.pipeline_stages
         ), (
             "Duplicate `PipelineStage` object instances found in the pipeline stages input"
             " to `TrainingPipeline`. `PipelineStage` objects are not immutable, if you'd"
@@ -843,7 +865,7 @@ class TrainingPipeline:
             " multiple separate instances."
         )
 
-        self._ensure_pipeline_stages_all_have_at_least_one_valid_stage_component()
+        self._ensure_pipeline_stages_all_have_at_least_one_stage_component()
 
         self._current_stage: Optional[PipelineStage] = None
         self.rollout_count = 0
@@ -856,47 +878,58 @@ class TrainingPipeline:
             rollout_storage_uuids = self._get_uuids_of_rollout_storages(
                 self._named_storages
             )
-            assert len(rollout_storage_uuids) == 1, (
+            assert len(rollout_storage_uuids) <= 1, (
                 f"`rollout_storage_uuid` cannot be automatically inferred as there are multiple storages defined"
                 f" (ids: {rollout_storage_uuids}) of type `RolloutStorage`."
             )
-            rollout_storage_uuid = rollout_storage_uuids[0]
-        assert rollout_storage_uuid in self._named_storages
+            rollout_storage_uuid = next(iter(rollout_storage_uuids), None)
+        assert (
+            rollout_storage_uuid is None or rollout_storage_uuid in self._named_storages
+        )
         return rollout_storage_uuid
 
-    def _ensure_pipeline_stages_all_have_at_least_one_valid_stage_component(self):
+    def _ensure_pipeline_stages_all_have_at_least_one_stage_component(self):
         rollout_storages_uuids = self._get_uuids_of_rollout_storages(
             self._named_storages
         )
 
-        for sit, stage in enumerate(self.pipeline_stages):
+        named_pipeline_stages = {
+            f"{i}th": ps for i, ps in enumerate(self.pipeline_stages)
+        }
+
+        named_pipeline_stages["valid"] = self.valid_pipeline_stage
+        named_pipeline_stages["test"] = self.test_pipeline_stage
+
+        for stage_name, stage in named_pipeline_stages.items():
             # Forward default `TrainingSettings` to all `PipelineStage`s settings:
             stage.training_settings.set_defaults(defaults=self.training_settings)
 
             if len(stage.stage_components) == 0:
-                assert len(rollout_storages_uuids) == 1, (
-                    f"In {sit}th pipeline stage: you have several storages specified ({rollout_storages_uuids}) which"
+                assert len(rollout_storages_uuids) <= 1, (
+                    f"In {stage_name} pipeline stage: you have several storages specified ({rollout_storages_uuids}) which"
                     f" are subclasses of `RolloutStorage`. This is only allowed when stage components are explicitly"
                     f" defined in every `PipelineStage` instance. You have `PipelineStage`s for which stage components"
                     f" are not specified."
                 )
-                stage.add_stage_component(
-                    StageComponent(
-                        uuid=rollout_storages_uuids[0],
-                        storage_uuid=rollout_storages_uuids[0],
-                        loss_names=stage.loss_names,
-                        training_settings=TrainingSettings(),
+                if len(rollout_storages_uuids) > 0:
+                    stage.add_stage_component(
+                        StageComponent(
+                            uuid=rollout_storages_uuids[0],
+                            storage_uuid=rollout_storages_uuids[0],
+                            loss_names=stage.loss_names,
+                            training_settings=TrainingSettings(),
+                        )
                     )
-                )
 
             for sc in stage.stage_components:
                 assert sc.storage_uuid in self._named_storages, (
-                    f"In {sit}th pipeline stage: storage with name '{sc.storage_uuid}' not found in collection of"
+                    f"In {stage_name} pipeline stage: storage with name '{sc.storage_uuid}' not found in collection of"
                     f" defined storages names: {list(self._named_storages.keys())}"
                 )
 
             if (
-                self.rollout_storage_uuid
+                self.rollout_storage_uuid is not None
+                and self.rollout_storage_uuid
                 not in stage.storage_uuid_to_steps_taken_in_stage
             ):
                 stage.storage_uuid_to_steps_taken_in_stage[
@@ -1000,6 +1033,13 @@ class TrainingPipeline:
     def restart_pipeline(self):
         for ps in self.pipeline_stages:
             ps.reset()
+
+        if self.valid_pipeline_stage:
+            self.valid_pipeline_stage.reset()
+
+        if self.test_pipeline_stage:
+            self.test_pipeline_stage.reset()
+
         self._current_stage = None
         self._refresh_current_stage(force_stage_search_from_start=True)
 
@@ -1042,21 +1082,32 @@ class TrainingPipeline:
         self._refresh_current_stage(force_stage_search_from_start=True)
 
     @property
-    def rollout_storage(self) -> RolloutStorage:
-        return cast(
-            RolloutStorage, self.current_stage_storage[self.rollout_storage_uuid]
+    def rollout_storage(self) -> Optional[RolloutStorage]:
+        if self.rollout_storage_uuid is None:
+            return None
+
+        rs = self._named_storages[self.rollout_storage_uuid]
+        if isinstance(rs, Builder):
+            rs = rs()
+            self._named_storages[self.rollout_storage_uuid] = rs
+
+        return cast(RolloutStorage, rs)
+
+    def get_stage_storage(
+        self, stage: PipelineStage
+    ) -> "OrderedDict[str, ExperienceStorage]":
+        storage_uuids_for_current_stage_set = set(
+            sc.storage_uuid for sc in stage.stage_components
         )
 
-    @property
-    def current_stage_storage(self) -> "OrderedDict[str, ExperienceStorage]":
+        # Always include self.rollout_storage_uuid in the current stage storage (when the uuid is defined)
+        if self.rollout_storage_uuid is not None:
+            storage_uuids_for_current_stage_set.add(self.rollout_storage_uuid)
+
         storage_uuids_for_current_stage = sorted(
-            list(
-                set(sc.storage_uuid for sc in self.current_stage.stage_components)
-                | {
-                    self.rollout_storage_uuid
-                }  # Always include self.rollout_storage_uuid
-            )
+            list(storage_uuids_for_current_stage_set)
         )
+
         for storage_uuid in storage_uuids_for_current_stage:
             if isinstance(self._named_storages[storage_uuid], Builder):
                 self._named_storages[storage_uuid] = cast(
@@ -1066,6 +1117,10 @@ class TrainingPipeline:
         return OrderedDict(
             (k, self._named_storages[k]) for k in storage_uuids_for_current_stage
         )
+
+    @property
+    def current_stage_storage(self) -> "OrderedDict[str, ExperienceStorage]":
+        return self.get_stage_storage(self.current_stage)
 
     def get_loss(self, uuid: str):
         if isinstance(self._named_losses[uuid], Builder):

--- a/allenact_plugins/habitat_plugin/habitat_environment.py
+++ b/allenact_plugins/habitat_plugin/habitat_environment.py
@@ -2,15 +2,15 @@
 import os
 from typing import Dict, Union, List, Optional
 
-import habitat
 import numpy as np
+
+import habitat
+from allenact.utils.cache_utils import DynamicDistanceCache
+from allenact.utils.system import get_logger
 from habitat.config import Config
 from habitat.core.dataset import Dataset
 from habitat.core.simulator import Observations, AgentState, ShortestPathPoint
 from habitat.tasks.nav.nav import NavigationEpisode as HabitatNavigationEpisode
-
-from allenact.utils.cache_utils import DynamicDistanceCache
-from allenact.utils.system import get_logger
 
 
 class HabitatEnvironment:

--- a/allenact_plugins/ithor_plugin/ithor_sensors.py
+++ b/allenact_plugins/ithor_plugin/ithor_sensors.py
@@ -32,9 +32,7 @@ THOR_TASK_TYPE = Union[
 ]
 
 
-class RGBSensorThor(
-    RGBSensor[THOR_ENV_TYPE, THOR_TASK_TYPE]
-):
+class RGBSensorThor(RGBSensor[THOR_ENV_TYPE, THOR_TASK_TYPE]):
     """Sensor for RGB images in THOR.
 
     Returns from a running IThorEnvironment instance, the current RGB

--- a/projects/babyai_baselines/experiments/go_to_obj/base.py
+++ b/projects/babyai_baselines/experiments/go_to_obj/base.py
@@ -53,6 +53,7 @@ class BaseBabyAIGoToObjExperimentConfig(BaseBabyAIExperimentConfig, ABC):
         update_repeats: int,
         total_train_steps: int,
         lr: Optional[float] = None,
+        **kwargs,
     ):
         lr = cls.DEFAULT_LR
 
@@ -87,6 +88,7 @@ class BaseBabyAIGoToObjExperimentConfig(BaseBabyAIExperimentConfig, ABC):
             )
             if cls.USE_LR_DECAY
             else None,
+            **kwargs,
         )
 
     @classmethod

--- a/tests/hierarchical_policies/test_minigrid_conditional.py
+++ b/tests/hierarchical_policies/test_minigrid_conditional.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional, List, Any, cast
 import os
+from tempfile import mkdtemp
+from typing import Dict, Optional, List, Any, cast
 
 import gym
 from gym_minigrid.envs import EmptyRandomEnv5x5
@@ -7,7 +8,9 @@ from torch import nn
 from torch import optim
 from torch.optim.lr_scheduler import LambdaLR
 
+from allenact.algorithms.onpolicy_sync.losses.imitation import Imitation
 from allenact.algorithms.onpolicy_sync.losses.ppo import PPO, PPOConfig
+from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner
 from allenact.base_abstractions.experiment_config import ExperimentConfig, TaskSampler
 from allenact.base_abstractions.sensor import SensorSuite, ExpertActionSensor
 from allenact.utils.experiment_utils import (
@@ -18,9 +21,6 @@ from allenact.utils.experiment_utils import (
 )
 from allenact_plugins.minigrid_plugin.minigrid_sensors import EgocentricMiniGridSensor
 from allenact_plugins.minigrid_plugin.minigrid_tasks import MiniGridTaskSampler
-from allenact.algorithms.onpolicy_sync.losses.imitation import Imitation
-from tempfile import mkdtemp
-from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner
 from projects.tutorials.minigrid_tutorial_conds import (
     ConditionedMiniGridSimpleConvRNN,
     ConditionedMiniGridTask,
@@ -214,7 +214,7 @@ class TestMiniGridCond:
             max_sampler_processes_per_worker=1,
             inference_expert=True,
         )
-        assert test_results[-1]["ep_length"] < 4
+        assert test_results[-1]["test-metrics/ep_length"] < 4
 
 
 if __name__ == "__main__":

--- a/tests/sync_algs_cpu/test_to_to_obj_trains.py
+++ b/tests/sync_algs_cpu/test_to_to_obj_trains.py
@@ -222,20 +222,24 @@ class RedirectOutput:
         self.f = io.StringIO()
         self.redirect_stdout = redirect_stdout(self.f)
         self.redirect_stderr = redirect_stderr(self.f)
-        self.capsys_output = ""
+        # self.capsys_output = ""
+        self.capsys_disabler = None
 
     def get_output(self):
-        return self.f.getvalue() + self.capsys_output
+        return self.f.getvalue() # + self.capsys_output
 
     def __enter__(self):
         if self.capsys is not None:
-            self.capsys.readouterr()  # Clear out any existing output
+            # self.capsys.readouterr()  # Clear out any existing output
+            self.capsys_disabler = self.capsys.disabled()
+            self.capsys_disabler.__enter__()
         self.redirect_stdout.__enter__()
         self.redirect_stderr.__enter__()
 
     def __exit__(self, *args):
         if self.capsys is not None:
-            self.capsys_output = self.capsys.readouterr().out
+            # self.capsys_output = self.capsys.readouterr().out
+            self.capsys_disabler.__exit__(*args)
         self.redirect_stdout.__exit__(*args)
         self.redirect_stderr.__exit__(*args)
 

--- a/tests/sync_algs_cpu/test_to_to_obj_trains.py
+++ b/tests/sync_algs_cpu/test_to_to_obj_trains.py
@@ -1,6 +1,7 @@
 import io
 import math
 import os
+import pathlib
 from contextlib import redirect_stdout, redirect_stderr
 from typing import Optional, List, Dict, Any
 
@@ -217,7 +218,10 @@ class TestGoToObjTrains:
         cfg = PPOBabyAIGoToObjTestExperimentConfig()
 
         d = tmpdir / "test_ppo_trains"
-        d.mkdir(parents=True, exist_ok=True)
+        if isinstance(d, pathlib.Path):
+            d.mkdir(parents=True, exist_ok=True)
+        else:
+            d.mkdir()
         output_dir = str(d)
 
         train_runner = OnPolicyRunner(
@@ -317,8 +321,6 @@ class TestGoToObjTrains:
 
 
 if __name__ == "__main__":
-    import pathlib
-
     TestGoToObjTrains().test_ppo_trains(
-        pathlib.Path("experiment_output/testing")
+        pathlib.Path("experiment_output/testing"), using_pytest=True
     )  # type:ignore

--- a/tests/sync_algs_cpu/test_to_to_obj_trains.py
+++ b/tests/sync_algs_cpu/test_to_to_obj_trains.py
@@ -296,7 +296,7 @@ class TestGoToObjTrains:
             def try_float(f):
                 try:
                     return float(f)
-                except:
+                except ValueError:
                     return f
 
             metrics_and_losses_dict = {

--- a/tests/sync_algs_cpu/test_to_to_obj_trains.py
+++ b/tests/sync_algs_cpu/test_to_to_obj_trains.py
@@ -1,17 +1,224 @@
+import io
 import math
 import os
+from contextlib import redirect_stdout, redirect_stderr
+from typing import Optional, List, Dict, Any
 
+import torch
+
+from allenact.algorithms.onpolicy_sync.losses.abstract_loss import (
+    AbstractActorCriticLoss,
+)
+from allenact.algorithms.onpolicy_sync.policy import ObservationType
 from allenact.algorithms.onpolicy_sync.runner import OnPolicyRunner
+from allenact.algorithms.onpolicy_sync.storage import (
+    StreamingStorageMixin,
+    ExperienceStorage,
+    RolloutBlockStorage,
+)
+from allenact.base_abstractions.experiment_config import MachineParams
+from allenact.base_abstractions.misc import (
+    Memory,
+    GenericAbstractLoss,
+    ModelType,
+    LossOutput,
+)
+from allenact.utils.experiment_utils import PipelineStage, StageComponent
+from allenact.utils.misc_utils import prepare_locals_for_super
 from projects.babyai_baselines.experiments.go_to_obj.ppo import (
     PPOBabyAIGoToObjExperimentConfig,
 )
 
+SILLY_STORAGE_VALUES = [1.0, 2.0, 3.0, 4.0]
+SILLY_STORAGE_REPEATS = [1, 2, 3, 4]
 
-class TestGoToObjTrains(object):
+
+class FixedConstantLoss(AbstractActorCriticLoss):
+    def __init__(self, name: str, value: float):
+        super().__init__()
+        self.name = name
+        self.value = value
+
+    def loss(  # type: ignore
+        self, *args, **kwargs,
+    ):
+        return self.value, {self.name: self.value}
+
+
+class SillyStorage(ExperienceStorage, StreamingStorageMixin):
+    def __init__(self, values_to_return: List[float], repeats: List[int]):
+        self.values_to_return = values_to_return
+        self.repeats = repeats
+        assert len(self.values_to_return) == len(self.repeats)
+        self.index = 0
+
+    def initialize(self, *, observations: ObservationType, **kwargs):
+        pass
+
+    def add(
+        self,
+        observations: ObservationType,
+        memory: Optional[Memory],
+        actions: torch.Tensor,
+        action_log_probs: torch.Tensor,
+        value_preds: torch.Tensor,
+        rewards: torch.Tensor,
+        masks: torch.Tensor,
+    ):
+        pass
+
+    def to(self, device: torch.device):
+        pass
+
+    def set_partition(self, index: int, num_parts: int):
+        pass
+
+    @property
+    def total_experiences(self) -> int:
+        return 0
+
+    @total_experiences.setter
+    def total_experiences(self, value: int):
+        pass
+
+    def next_batch(self) -> Dict[str, Any]:
+        if self.index >= len(self.values_to_return):
+            raise EOFError
+
+        to_return = {
+            "value": torch.tensor(
+                [self.values_to_return[self.index]] * self.repeats[self.index]
+            ),
+        }
+        self.index += 1
+        return to_return
+
+    def reset_stream(self):
+        self.index = 0
+
+    def empty(self) -> bool:
+        return len(self.values_to_return) == 0
+
+
+class AverageBatchValueLoss(GenericAbstractLoss):
+    def loss(
+        self,
+        *,
+        model: ModelType,
+        batch: ObservationType,
+        batch_memory: Memory,
+        stream_memory: Memory,
+    ) -> LossOutput:
+        v = batch["value"].mean()
+        return LossOutput(
+            value=v,
+            info={"avg_batch_val": v},
+            per_epoch_info={},
+            batch_memory=batch_memory,
+            stream_memory=stream_memory,
+            bsize=batch["value"].shape[0],
+        )
+
+
+class PPOBabyAIGoToObjTestExperimentConfig(PPOBabyAIGoToObjExperimentConfig):
+    NUM_CKPTS_TO_SAVE = 2
+
+    @classmethod
+    def tag(cls):
+        return "BabyAIGoToObjPPO-TESTING"
+
+    @classmethod
+    def machine_params(cls, mode="train", **kwargs):
+        mp = super().machine_params(mode=mode, **kwargs)
+        if mode == "valid":
+            mp = MachineParams(
+                nprocesses=1,
+                devices=mp.devices,
+                sensor_preprocessor_graph=mp.sensor_preprocessor_graph,
+                sampler_devices=mp.sampler_devices,
+                visualizer=mp.visualizer,
+                local_worker_ids=mp.local_worker_ids,
+            )
+        return mp
+
+    @classmethod
+    def training_pipeline(cls, **kwargs):
+        total_train_steps = cls.TOTAL_RL_TRAIN_STEPS
+        ppo_info = cls.rl_loss_default("ppo", steps=total_train_steps)
+
+        tp = cls._training_pipeline(
+            named_losses={
+                "ppo_loss": ppo_info["loss"],
+                "3_loss": FixedConstantLoss("3_loss", 3.0),
+                "avg_value_loss": AverageBatchValueLoss(),
+            },
+            named_storages={
+                "onpolicy": RolloutBlockStorage(),
+                "silly_storage": SillyStorage(
+                    values_to_return=SILLY_STORAGE_VALUES, repeats=SILLY_STORAGE_REPEATS
+                ),
+            },
+            pipeline_stages=[
+                PipelineStage(
+                    loss_names=["ppo_loss", "3_loss"],
+                    max_stage_steps=total_train_steps,
+                    stage_components=[
+                        StageComponent(
+                            uuid="onpolicy",
+                            storage_uuid="onpolicy",
+                            loss_names=["ppo_loss", "3_loss"],
+                        )
+                    ],
+                ),
+            ],
+            num_mini_batch=ppo_info["num_mini_batch"],
+            update_repeats=ppo_info["update_repeats"],
+            total_train_steps=total_train_steps,
+            valid_pipeline_stage=PipelineStage(
+                loss_names=["ppo_loss", "3_loss"],
+                max_stage_steps=-1,
+                update_repeats=1,
+                num_mini_batch=1,
+            ),
+            test_pipeline_stage=PipelineStage(
+                loss_names=["avg_value_loss"],
+                stage_components=[
+                    StageComponent(
+                        uuid="debug",
+                        storage_uuid="silly_storage",
+                        loss_names=["avg_value_loss"],
+                    ),
+                ],
+                max_stage_steps=-1,
+                update_repeats=1,
+                num_mini_batch=1,
+            ),
+        )
+
+        tp.training_settings.save_interval = int(
+            math.ceil(cls.TOTAL_RL_TRAIN_STEPS / cls.NUM_CKPTS_TO_SAVE)
+        )
+        return tp
+
+    def valid_task_sampler_args(
+        self,
+        process_ind: int,
+        total_processes: int,
+        devices: Optional[List[int]] = None,
+        seeds: Optional[List[int]] = None,
+        deterministic_cudnn: bool = False,
+    ) -> Dict[str, Any]:
+        # Also run validation
+        return self.test_task_sampler_args(**prepare_locals_for_super(locals()))
+
+
+class TestGoToObjTrains:
     def test_ppo_trains(self, tmpdir):
-        cfg = PPOBabyAIGoToObjExperimentConfig()
+        cfg = PPOBabyAIGoToObjTestExperimentConfig()
 
-        output_dir = tmpdir.mkdir("experiment_output")
+        d = tmpdir / "test_ppo_trains"
+        d.mkdir(parents=True, exist_ok=True)
+        output_dir = str(d)
 
         train_runner = OnPolicyRunner(
             config=cfg,
@@ -22,7 +229,42 @@ class TestGoToObjTrains(object):
             deterministic_cudnn=True,
         )
 
-        start_time_str = train_runner.start_train(max_sampler_processes_per_worker=1)
+        f = io.StringIO()
+        with redirect_stdout(f), redirect_stderr(f):
+            start_time_str = train_runner.start_train(
+                max_sampler_processes_per_worker=1
+            )
+        s = f.getvalue()
+
+        def extract_final_metrics_from_log(s: str, mode: str):
+            lines = s.splitlines()
+            lines = [l for l in lines if mode.upper() in l]
+            metrics_and_losses_list = (
+                lines[-1].split(")")[-1].split("[")[0].strip().split(" ")
+            )
+
+            def try_float(f):
+                try:
+                    return float(f)
+                except:
+                    return f
+
+            metrics_and_losses_dict = {
+                k: try_float(v)
+                for k, v in zip(
+                    metrics_and_losses_list[::2], metrics_and_losses_list[1::2]
+                )
+            }
+            return metrics_and_losses_dict
+
+        train_metrics = extract_final_metrics_from_log(s, "train")
+        assert train_metrics["global_batch_size"] == 256
+
+        valid_metrics = extract_final_metrics_from_log(s, "valid")
+        assert valid_metrics["3_loss/3_loss"] == 3, "Incorrect validation loss"
+        assert (
+            valid_metrics["new_tasks_completed"] == cfg.NUM_TEST_TASKS
+        ), "Incorrect number of tasks evaluated in validation"
 
         test_runner = OnPolicyRunner(
             config=cfg,
@@ -32,6 +274,7 @@ class TestGoToObjTrains(object):
             mode="test",
             deterministic_cudnn=True,
         )
+
         test_results = test_runner.start_test(
             checkpoint_path_dir_or_pattern=os.path.join(
                 output_dir, "checkpoints", "**", start_time_str, "*.pt"
@@ -40,10 +283,10 @@ class TestGoToObjTrains(object):
         )
 
         assert (
-            len(test_results) == 1
+            len(test_results) == 2
         ), f"Too many or too few test results ({test_results})"
 
-        tr = test_results[0]
+        tr = test_results[-1]
         assert (
             tr["training_steps"]
             == round(
@@ -56,17 +299,26 @@ class TestGoToObjTrains(object):
             * cfg.NUM_TRAIN_SAMPLERS
         ), "Incorrect number of training steps"
         assert len(tr["tasks"]) == cfg.NUM_TEST_TASKS, "Incorrect number of test tasks"
-        assert tr["success"] == sum(task["success"] for task in tr["tasks"]) / len(
-            tr["tasks"]
-        ), "Success counts don't seem to match"
+        assert tr["test-metrics/success"] == sum(
+            task["success"] for task in tr["tasks"]
+        ) / len(tr["tasks"]), "Success counts don't seem to match"
         assert (
-            tr["success"] > 0.95
-        ), "PPO did not seem to converge for the go_to_obj task (success {}).".format(
-            tr["success"]
-        )
+            tr["test-metrics/success"] > 0.95
+        ), f"PPO did not seem to converge for the go_to_obj task (success {tr['success']})."
+        assert tr["test-debug-losses/avg_value_loss/avg_batch_val"] == sum(
+            ssv * ssr for ssv, ssr in zip(SILLY_STORAGE_VALUES, SILLY_STORAGE_REPEATS)
+        ) / sum(SILLY_STORAGE_REPEATS)
+        assert tr["test-debug-losses/avg_value_loss/avg_batch_val"] == sum(
+            ssv * ssr for ssv, ssr in zip(SILLY_STORAGE_VALUES, SILLY_STORAGE_REPEATS)
+        ) / sum(SILLY_STORAGE_REPEATS)
+        assert tr["test-debug-misc/worker_batch_size"] == sum(
+            SILLY_STORAGE_VALUES
+        ) / len(SILLY_STORAGE_VALUES)
 
 
 if __name__ == "__main__":
     import pathlib
 
-    TestGoToObjTrains().test_ppo_trains(pathlib.Path("testing"))  # type:ignore
+    TestGoToObjTrains().test_ppo_trains(
+        pathlib.Path("experiment_output/testing")
+    )  # type:ignore


### PR DESCRIPTION
This PR primarily makes changes to the engine.py files to allow for computing losses during validation and testing. This is a feature that is especially useful when one is training with only off-policy datasets. To make this possible I also unified the logging code in `runner.py`.